### PR TITLE
feat: call liff.init automatically if liff.init is called in LIFF browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ liff.init({
   mock: true, // enable mock mode
 });
 
+if (!liff.isInClient()) liff.login();
 const profile = await liff.getProfile();
 // { displayName: 'Brown', userId: '123456789', statusMessage: 'hello' }
 console.log(profile);
@@ -48,6 +49,7 @@ liff.init({
   mock: true, // enable mock mode
 });
 
+if (!liff.isInClient()) liff.login();
 const profile = await liff.getProfile();
 // { displayName: 'Brown', userId: '123456789', statusMessage: 'hello' }
 console.log(profile);

--- a/src/api/init.test.ts
+++ b/src/api/init.test.ts
@@ -1,0 +1,41 @@
+import { createMockedInit } from './init';
+import { globalStore } from '../store/GlobalStore';
+
+describe('mockedInit', () => {
+  beforeEach(() => {
+    globalStore.resetAll();
+  });
+
+  it('should call injectLiffMock', async () => {
+    const injectLiffMock = jest.fn();
+    const isInClient = false;
+    const mockedInit = createMockedInit(injectLiffMock, isInClient);
+    await mockedInit({ liffId: 'xx' });
+    expect(injectLiffMock).toBeCalledTimes(1);
+    expect(globalStore.numberOfInitCalled).toBe(1);
+    expect(globalStore.numberOfLoginCalled).toBe(0);
+  });
+
+  it('should call liff.login when in LIFF Browser', async () => {
+    const injectLiffMock = jest.fn();
+    // In LIFF Browser
+    const isInClient = true;
+    const mockedInit = createMockedInit(injectLiffMock, isInClient);
+    await mockedInit({ liffId: 'xx' });
+    expect(injectLiffMock).toBeCalledTimes(1);
+    expect(globalStore.numberOfInitCalled).toBe(1);
+    expect(globalStore.numberOfLoginCalled).toBe(1);
+  });
+
+  it('should not call injectLiffMock and liff.login if liff.init is already called', async () => {
+    const injectLiffMock = jest.fn();
+    const isInClient = true;
+    const mockedInit = createMockedInit(injectLiffMock, isInClient);
+    await mockedInit({ liffId: 'xx' });
+    expect(injectLiffMock).toBeCalledTimes(1);
+    expect(globalStore.numberOfLoginCalled).toBe(1);
+    await mockedInit({ liffId: 'xx' });
+    expect(injectLiffMock).toBeCalledTimes(1);
+    expect(globalStore.numberOfLoginCalled).toBe(1);
+  });
+});

--- a/src/api/init.ts
+++ b/src/api/init.ts
@@ -39,7 +39,8 @@ import { _removeListener } from './_removeListener';
 export const createMockedInit = (
   injectLiffMock: (
     liff: Omit<ActualLiff, 'init' | 'use' | 'ready' | 'id'>
-  ) => void
+  ) => void,
+  isCalledInLiffBrowser: boolean
 ): ActualLiff['init'] => {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const init: ActualLiff['init'] = (config, successCallback, errorCallback) => {
@@ -88,6 +89,12 @@ export const createMockedInit = (
     }
 
     globalStore.initIsCalled();
+
+    // Login automatically if LIFF app is running in LIFF browser
+    // https://developers.line.biz/en/reference/liff/#login
+    if (isCalledInLiffBrowser && globalStore.numberOfLoginCalled === 0) {
+      login();
+    }
 
     if (typeof successCallback === 'function') {
       successCallback();

--- a/src/plugin.test.ts
+++ b/src/plugin.test.ts
@@ -14,13 +14,14 @@ describe('LiffMockPlugin', () => {
     expect(new LiffMockPlugin().name).toBe('mock');
   });
 
-  it('should call createMockedInit and getActualInitOrMockedInit, and then replace liff.init', () => {
+  it('should replace liff.init with mocked one', () => {
     const init = jest.fn();
+    const isInClient = jest.fn().mockImplementation(() => false);
     const mockedInit = jest.fn();
     _createMockedInit.mockImplementation(() => mockedInit);
     _getActualInitOrMockedInit.mockImplementation(() => mockedInit);
 
-    const liff = { id: 'id', init } as unknown as ActualLiff;
+    const liff = { id: 'id', init, isInClient } as unknown as ActualLiff;
 
     const module = new LiffMockPlugin();
     module.install({ liff, hooks: {} as any });
@@ -28,12 +29,14 @@ describe('LiffMockPlugin', () => {
     expect(_createMockedInit).toBeCalledTimes(1);
     expect(_getActualInitOrMockedInit).toBeCalledTimes(1);
     expect(_getActualInitOrMockedInit).toBeCalledWith(init, mockedInit);
+    expect(isInClient).toBeCalledTimes(1);
     expect(liff.id).toBe('id'); // preserved
     expect(liff.init).toBe(mockedInit); // replaced
   });
 
   it('should return module APIs, `set` and `clear`', () => {
-    const liff = {} as unknown as ActualLiff;
+    const isInClient = jest.fn().mockImplementation(() => false);
+    const liff = { isInClient } as unknown as ActualLiff;
 
     const module = new LiffMockPlugin();
     const res = module.install({ liff, hooks: {} as any });

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -10,12 +10,15 @@ export class LiffMockPlugin implements LiffPlugin<LiffMockApi> {
 
   install({ liff }: LiffPluginContext): LiffMockApi {
     const originalInit = liff.init;
+    const isInClient = liff.isInClient();
+
     const mockedInit = createMockedInit((mockedLiff) => {
       Object.entries(mockedLiff).forEach(([key, value]) => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (liff as any)[key] = value;
       });
-    });
+    }, isInClient);
+
     liff.init = getActualInitOrMockedInit(originalInit, mockedInit);
 
     return {


### PR DESCRIPTION
LIFF App in LIFF Browser doesn't have to call `liff.login` since it is invoked by `liff.init` automatically.
https://developers.line.biz/en/reference/liff/#login

This PR fixed to align `liff.init` behavior.