### PR TITLE
feat: Add CDN example app

### DIFF
--- a/examples/cdn-example/index.html
+++ b/examples/cdn-example/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>LIFF Mock example</title>
+    <script
+      charset="utf-8"
+      src="https://static.line-scdn.net/liff/edge/versions/2.19.0/sdk.js"
+    ></script>
+    <script src="https://unpkg.com/@line/liff-mock@1.0.2/dist/umd/liff-mock.js"></script>
+    <script type="module" src="index.js"></script>
+  </head>
+  <body>
+    <p>Open Network Tab on DevTools and check there is no request/response log.</p>
+    <br />
+    <button id="init_btn">init</button>
+    <button id="login_btn">login()</button>
+    <button id="get_profile_btn">getProfile()</button>
+  </body>
+</html>

--- a/examples/cdn-example/index.js
+++ b/examples/cdn-example/index.js
@@ -1,0 +1,42 @@
+const liff = window.liff;
+const liffMockPlugin = window.liffMock;
+
+liff.use(new liffMockPlugin());
+
+const main = () => {
+  document.getElementById('init_btn').onclick = onInitClick;
+  document.getElementById('login_btn').onclick = login;
+  document.getElementById('get_profile_btn').onclick = getProfile;
+};
+
+const onInitClick = async () => {
+  try {
+    await liff.init({
+      liffId: 'xxx',
+      mock: true,
+    });
+    console.log('liff.init done');
+  } catch (e) {
+    console.error('liff.init error', e);
+  }
+};
+
+const login = async () => {
+  try {
+    await liff.login();
+  } catch (e) {
+    console.log('liff.login done');
+    console.error('liff.login error', e);
+  }
+};
+
+const getProfile = async () => {
+  try {
+    const profile = await liff.getProfile();
+    console.log('liff.getProfile: ', profile);
+  } catch (e) {
+    console.error('liff.getProfile error', e);
+  }
+};
+
+window.onload = main;

--- a/examples/cdn-example/index.js
+++ b/examples/cdn-example/index.js
@@ -24,8 +24,8 @@ const onInitClick = async () => {
 const login = async () => {
   try {
     await liff.login();
-  } catch (e) {
     console.log('liff.login done');
+  } catch (e) {
     console.error('liff.login error', e);
   }
 };


### PR DESCRIPTION
Page: https://line.github.io/liff-mock/examples/cdn-example/

This PR added super simple example app for CDN usage.
The target brunch of GitHub pages is now `add-cdn-example` but I'll change it to `main` after this PR is landed.