### PR TITLE
improve README.md for use with pluggable sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,14 @@ console.log(profile);
 
 ### With [Pluggable SDK](https://developers.line.biz/en/docs/liff/pluggable-sdk/)
 
+If you use LIFF Mock with Pluggable SDK mode, you have to install `IsInClientModule` before the installation of `LiffMockPlugin` because LIFF Mock depends on `liff.isInClient` API.
+
 ```ts
 import liff from '@line/liff/core';
 import IsInClientModule from "@line/liff/is-in-client";
 import { LiffMockPlugin } from '@line/liff-mock';
 
-liff.use(new IsInClientModule());
+liff.use(new IsInClientModule());  // <-- Please install IsInClientModule before LiffMockPlugin
 liff.use(new LiffMockPlugin());
 
 liff.init({

--- a/README.md
+++ b/README.md
@@ -29,6 +29,27 @@ const profile = await liff.getProfile();
 console.log(profile);
 ```
 
+### With [Pluggable SDK](https://developers.line.biz/en/docs/liff/pluggable-sdk/)
+
+```ts
+import liff from '@line/liff/core';
+import IsInClientModule from "@line/liff/is-in-client";
+import { LiffMockPlugin } from '@line/liff-mock';
+
+liff.use(new IsInClientModule());
+liff.use(new LiffMockPlugin());
+
+liff.init({
+  liffId: 'liff-xxxx',
+  mock: true, // enable mock mode
+});
+
+if (!liff.isInClient()) liff.login();
+const profile = await liff.getProfile();
+// { displayName: 'Brown', userId: '123456789', statusMessage: 'hello' }
+console.log(profile);
+```
+
 ## CDN
 
 https://unpkg.com/@line/liff-mock@1.0.3/dist/umd/liff-mock.js


### PR DESCRIPTION
Related: https://github.com/line/liff-mock/issues/14

`liff-mock` uses `liff.isInClient` internally.
Therefore, if you use it with the Pluggable SDK, you need to do `liff.use(new IsInClientModule());`.

I have added this to RAEDME.md