### PR TITLE
Declare `@line/liff` module types in the entry file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.3",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@line/liff": "2.21.3",
+        "@line/liff": "2.22.2",
         "@types/jest": "27.4.1",
         "@typescript-eslint/eslint-plugin": "5.19.0",
         "@typescript-eslint/parser": "5.19.0",
@@ -982,354 +982,391 @@
       "dev": true
     },
     "node_modules/@liff/add-to-home-screen": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/add-to-home-screen/-/add-to-home-screen-2.21.3.tgz",
-      "integrity": "sha512-KWbEXr/H4uDWH2jTt2jYG36KuxrL0laiJ93VG0fELW3JoWMFAisQMoLiIXe/I5NkT4nZlr3g0vN1nG7bKHX15A==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/add-to-home-screen/-/add-to-home-screen-2.22.2.tgz",
+      "integrity": "sha512-KyL3DAtRtt8gf3irS3zAGpnSkqkc75EDQEIVajWh1FRwrKy/oS6sgfl6Gcjac7Jq2DOLUkwN1DA15fBuBpWdWw==",
       "dev": true,
       "dependencies": {
-        "@liff/check-availability": "2.21.3",
-        "@liff/consts": "2.21.3",
-        "@liff/is-in-client": "2.21.3",
-        "@liff/is-sub-window": "2.21.3",
-        "@liff/native-bridge": "2.21.3",
-        "@liff/open-window": "2.21.3",
-        "@liff/util": "2.21.3"
+        "@liff/consts": "2.22.2",
+        "@liff/open-window": "2.22.2",
+        "@liff/types": "2.22.2",
+        "@liff/util": "2.22.2"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/analytics": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/analytics/-/analytics-2.21.3.tgz",
-      "integrity": "sha512-yPTzG3ekBDQUNRtAbZZSMfviMjJ9MDPNABTwWPTBSQ1msyxvQ8QffZBhmaeLp7Q21379SH7wRJj05iZixX2Lng==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/analytics/-/analytics-2.22.2.tgz",
+      "integrity": "sha512-wFk3VpmZSmOtDHKeU9jvn/VRhioCxpaO9r9kXXMo8znpg6PaP/0gGAIWEJxEF6GWhSE+GbAgHZYE+E4i5I1V0g==",
       "dev": true,
       "dependencies": {
-        "@liff/consts": "2.21.3",
-        "@liff/get-profile": "2.21.3",
-        "@liff/get-version": "2.21.3",
-        "@liff/is-logged-in": "2.21.3",
-        "@liff/logger": "2.21.3",
-        "@liff/store": "2.21.3",
-        "@liff/types": "2.21.3",
-        "@liff/use": "2.21.3",
-        "@liff/util": "2.21.3"
+        "@liff/consts": "2.22.2",
+        "@liff/core": "2.22.2",
+        "@liff/get-profile": "2.22.2",
+        "@liff/get-version": "2.22.2",
+        "@liff/is-logged-in": "2.22.2",
+        "@liff/logger": "2.22.2",
+        "@liff/store": "2.22.2",
+        "@liff/types": "2.22.2",
+        "@liff/use": "2.22.2",
+        "@liff/util": "2.22.2"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/check-availability": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/check-availability/-/check-availability-2.21.3.tgz",
-      "integrity": "sha512-BUyHWQ+B8+3EtWr9sBtrOV7M+GsKacyC0dwUskNBifWaoXg1IEqEX18O49NjoFYK5bb2tz3H/YDw+zRKJMfHgQ==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/check-availability/-/check-availability-2.22.2.tgz",
+      "integrity": "sha512-aD6PGWrFbst7IkiPMuCyZkpYKqSUUYRE5v6gcsnxT6wBBeKZbwjK15XjV5VTMq//LQYR9eu03MremKEyV44bLg==",
       "dev": true,
       "dependencies": {
-        "@liff/get-version": "2.21.3",
-        "@liff/is-api-available": "2.21.3",
-        "@liff/util": "2.21.3"
+        "@liff/get-version": "2.22.2",
+        "@liff/is-api-available": "2.22.2",
+        "@liff/types": "2.22.2",
+        "@liff/util": "2.22.2"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/close-window": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/close-window/-/close-window-2.21.3.tgz",
-      "integrity": "sha512-4oaDLwrFw7icxyPlilOdGP2ZwJL/yioqcCWRfZT5IdYl/cy+ScCA+6uH6A9Y4F/M+9hUBghlVMXKCn2xuIBRww==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/close-window/-/close-window-2.22.2.tgz",
+      "integrity": "sha512-w0VozITe4MjQi3MfeTegnH3kt11U4E5JLMY9zM4vhxHJLXVD9g/Pvnp2NcKFN8BgraQFs9UF+NyfgRCknivhgA==",
       "dev": true,
       "dependencies": {
-        "@liff/get-line-version": "2.21.3",
-        "@liff/get-os": "2.21.3",
-        "@liff/native-bridge": "2.21.3",
-        "@liff/util": "2.21.3"
+        "@liff/get-line-version": "2.22.2",
+        "@liff/get-os": "2.22.2",
+        "@liff/native-bridge": "2.22.2",
+        "@liff/types": "2.22.2",
+        "@liff/use": "2.22.2",
+        "@liff/util": "2.22.2"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/consts": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/consts/-/consts-2.21.3.tgz",
-      "integrity": "sha512-/EKhFKC2gNCg6+8bC6hCGcEX48Ec9PFuBJ6z4CPRtehVq/LtBNOEtdhwRvLgKmvrRj2aztTFHHNvXC2TC08cBA==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/consts/-/consts-2.22.2.tgz",
+      "integrity": "sha512-uqqOIsDNkW9HHF3dYOcI4Usud9UiEOVtx3TOHidZzFFfGLJy7Yx7oYCZVooKw2QBpHaOXFGpupN1CKzKbYUQWg==",
       "dev": true,
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
-    "node_modules/@liff/extensions": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/extensions/-/extensions-2.21.3.tgz",
-      "integrity": "sha512-soJkiFcTTMhRMvDhY2ravRWGq3cXUnLbPh4a/0AcRtR8LAu/rivcpXJj5LKNCite5TNDd4h7PWtbJNY64k9LwQ==",
+    "node_modules/@liff/core": {
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/core/-/core-2.22.2.tgz",
+      "integrity": "sha512-rn1cXopCYWxON9rnybcX8PQxtn7S810OjMaV+4c6CJmF/POQU2h++z+A1ne1QI6YLjl918Hdu/sMYpgTfdUVaw==",
       "dev": true,
       "dependencies": {
-        "@liff/add-to-home-screen": "2.21.3",
-        "@liff/check-availability": "2.21.3",
-        "@liff/consts": "2.21.3",
-        "@liff/get-advertising-id": "2.21.3",
-        "@liff/get-line-version": "2.21.3",
-        "@liff/get-os": "2.21.3",
-        "@liff/logger": "2.21.3",
-        "@liff/scan-code": "2.21.3",
-        "@liff/store": "2.21.3",
-        "@liff/util": "2.21.3"
+        "@liff/get-version": "2.22.2",
+        "@liff/init": "2.22.2",
+        "@liff/native-bridge": "2.22.2",
+        "@liff/ready": "2.22.2",
+        "@liff/store": "2.22.2",
+        "@liff/use": "2.22.2"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/extensions": {
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/extensions/-/extensions-2.22.2.tgz",
+      "integrity": "sha512-8tRaJOMUnLadGXRPIPAqgHKBGqZ/5Th772Ga0dQ/7aGbrmw1oMCMTh0NRdGQ0F7MqNQsgSP4bocXDUDolqT2dw==",
+      "dev": true,
+      "dependencies": {
+        "@liff/add-to-home-screen": "2.22.2",
+        "@liff/check-availability": "2.22.2",
+        "@liff/consts": "2.22.2",
+        "@liff/get-advertising-id": "2.22.2",
+        "@liff/get-line-version": "2.22.2",
+        "@liff/get-os": "2.22.2",
+        "@liff/logger": "2.22.2",
+        "@liff/scan-code": "2.22.2",
+        "@liff/store": "2.22.2",
+        "@liff/types": "2.22.2",
+        "@liff/util": "2.22.2"
       }
     },
     "node_modules/@liff/get-advertising-id": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/get-advertising-id/-/get-advertising-id-2.21.3.tgz",
-      "integrity": "sha512-wa4SFXgSF0aYIe/jhv2fDQR29b8Oy8Zxgu8r8lPk3YMXWqEZVKu9yPX7G2nQOi+vqWmTXUfGuY35eKtVoPuf4Q==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/get-advertising-id/-/get-advertising-id-2.22.2.tgz",
+      "integrity": "sha512-ZlYOXGL7GcGFbIAAnrh+cju6+BnWXPC2GCbtWAKFb+cMc8F8DswD/+f8qG5rVIB/t78j+tTjP0cDBRsSFzboOQ==",
       "dev": true,
       "dependencies": {
-        "@liff/check-availability": "2.21.3",
-        "@liff/consts": "2.21.3",
-        "@liff/native-bridge": "2.21.3",
-        "@liff/util": "2.21.3"
+        "@liff/types": "2.22.2"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/get-friendship": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/get-friendship/-/get-friendship-2.21.3.tgz",
-      "integrity": "sha512-YCfYqeA74juAi7QGAlgksSXGsz9L7j+Lk+Z4wT01Csa1u6r1Km2NFvV+coxxwzAkcXmzX7plyWRtN611FNqXkw==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/get-friendship/-/get-friendship-2.22.2.tgz",
+      "integrity": "sha512-TqqO0M4QHGqP431mYoRRemTlW1zSz6ihjMS0cuGuPqFAvS5/gQ+8wUQOaIHR/oB0NZSOSNTZnayJ/+FFQPInVw==",
       "dev": true,
       "dependencies": {
-        "@liff/server-api": "2.21.3"
+        "@liff/permission": "2.22.2",
+        "@liff/server-api": "2.22.2",
+        "@liff/use": "2.22.2"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/get-language": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/get-language/-/get-language-2.21.3.tgz",
-      "integrity": "sha512-/A8bfmMczEZ+JfobB3BFgH3FUAVIg2l9fkQjZvBoAvt0S/uZudhquj8Ar7oI7yBAI4usH9W5tyUqiWP0lEhlMg==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/get-language/-/get-language-2.22.2.tgz",
+      "integrity": "sha512-+4vWYrOIFQpZMx75xLSVf1ZuNN2snh75dVHZ+TG/fl00VNgJF5sHkvglfy9dUNJkW7dMD61n3OSZUepgQUZBwA==",
       "dev": true,
+      "dependencies": {
+        "@liff/use": "2.22.2"
+      },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/get-line-version": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/get-line-version/-/get-line-version-2.21.3.tgz",
-      "integrity": "sha512-uNS3cpumPRq+qstOLgzFjapBJR9OHaEQmiBtzcDksu5xzK3+46mA6FfLOUX5FT/SLzpMauUOuJyIy1vp28Amcg==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/get-line-version/-/get-line-version-2.22.2.tgz",
+      "integrity": "sha512-CdKB0bpvenNbtRPeUCRwMJlULf7XWY3rC3AA/6qiIYv2eLdJnwc7jQvKv0Ma9Q1w1aQkQAYi5VJqYAVfeOu31Q==",
       "dev": true,
+      "dependencies": {
+        "@liff/use": "2.22.2"
+      },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/get-os": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/get-os/-/get-os-2.21.3.tgz",
-      "integrity": "sha512-q48QNBeUh7zYt1q7VdEkkUx9OudJrqDkG3EdhmRuxt6H4dxzXux1/oGXnl4ZWMrVLSQRCvu0Y3c4KHgh6hqmug==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/get-os/-/get-os-2.22.2.tgz",
+      "integrity": "sha512-N/gXG0zwR8O/ccYJhsSIxZ5UYEFvzKU+b7bbHAqDmIkq0pdBZ1YMTIL5iizbmpJQFl2+bfPWa3ultBG9X41TdA==",
       "dev": true,
+      "dependencies": {
+        "@liff/use": "2.22.2"
+      },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/get-profile": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/get-profile/-/get-profile-2.21.3.tgz",
-      "integrity": "sha512-jbVMFcaq8zTwJpLljD+AP71LQ6od0iNrT/JECSeGHd0ZgOsywbbNzi7jqZkh/0YJeios8xif4PKz3SHbJGpbVw==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/get-profile/-/get-profile-2.22.2.tgz",
+      "integrity": "sha512-nb3ljhpgawNpFJGNKMXHbGQIf+nSNUbPION0dcrw6PplRz/Y98DxqR56onioH0e2cuRlwzp2o+Tl90JpdSrJZA==",
       "dev": true,
       "dependencies": {
-        "@liff/server-api": "2.21.3"
+        "@liff/permission": "2.22.2",
+        "@liff/server-api": "2.22.2",
+        "@liff/use": "2.22.2"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/get-version": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/get-version/-/get-version-2.21.3.tgz",
-      "integrity": "sha512-mkzEhzcWTGkHzlH1D5TS2QIgMsLKAREX+UEfhCSOxObpsfXJX1DC1gBdnMIzrFbDLjmteUVnGKXmarzcYjBJzQ==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/get-version/-/get-version-2.22.2.tgz",
+      "integrity": "sha512-KYQBgMjfZbGM8wY+6O8O4D5NwvtzASLuPi8nwqo/Kfurb/z9K8Nyi7gZ9Ca9W6UXcStx+AC05itn0L60ZCB6Ew==",
       "dev": true,
+      "dependencies": {
+        "@liff/use": "2.22.2"
+      },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/hooks": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/hooks/-/hooks-2.21.3.tgz",
-      "integrity": "sha512-CEwh1DK4jwlm5wYGJv5PDvoECRh486fSsfqwW3Zokk8NYIr1jTbob04NsImmzxN+hokFESuJDPaQsf32aOWsEA==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/hooks/-/hooks-2.22.2.tgz",
+      "integrity": "sha512-P5C05CFUT6NDgi/Ur3TKHlUUtyuEQmBGM5dXezhKLtG72WY3lYTm2Y9yAcl8VU0z829+JJpM0J68gXArH03JUg==",
       "dev": true,
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/i18n": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/i18n/-/i18n-2.21.3.tgz",
-      "integrity": "sha512-aEojQEl8xyOLNRgkXaeTNLEy22MUuS3rFXmrzaoIrxYnEhLvIMN89xd7VEbv+1iUYwtB3dM0xqFoXhK6mhsUEA==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/i18n/-/i18n-2.22.2.tgz",
+      "integrity": "sha512-TIaXtONhfHc0L8HPvI0S+lyTJOHelFt+TVNLJ5/9eb4uoeqM+ksdCZcJ8PcvR4RK7R7SaNZk4n4plpGMizJcHw==",
       "dev": true,
       "dependencies": {
-        "@liff/consts": "2.21.3",
-        "@liff/server-api": "2.21.3",
-        "@liff/use": "2.21.3",
-        "@liff/util": "2.21.3"
+        "@liff/consts": "2.22.2",
+        "@liff/server-api": "2.22.2",
+        "@liff/use": "2.22.2",
+        "@liff/util": "2.22.2"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/init": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/init/-/init-2.21.3.tgz",
-      "integrity": "sha512-40AMTpO40AIxQ0+pSRIBKMCT2Y4xDmCx/qOQSqHKb3r1x8IUdz4yttqgUtAO9Pr/TQVr2F23i9DfDcsHGFtKvg==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/init/-/init-2.22.2.tgz",
+      "integrity": "sha512-wgywnI8dIhgr5bJkKqUaGrd71lgk/HGVNlWtt0y7/pV/Yp4yjKwn9Pzk9EwhjpPSUvVD+V9EaKYwkhRcHwbnkw==",
       "dev": true,
       "dependencies": {
-        "@liff/close-window": "2.21.3",
-        "@liff/consts": "2.21.3",
-        "@liff/extensions": "2.21.3",
-        "@liff/get-line-version": "2.21.3",
-        "@liff/get-os": "2.21.3",
-        "@liff/hooks": "2.21.3",
-        "@liff/i18n": "2.21.3",
-        "@liff/is-api-available": "2.21.3",
-        "@liff/is-in-client": "2.21.3",
-        "@liff/is-logged-in": "2.21.3",
-        "@liff/is-sub-window": "2.21.3",
-        "@liff/logger": "2.21.3",
-        "@liff/login": "2.21.3",
-        "@liff/logout": "2.21.3",
-        "@liff/message-bus": "2.21.3",
-        "@liff/native-bridge": "2.21.3",
-        "@liff/ready": "2.21.3",
-        "@liff/server-api": "2.21.3",
-        "@liff/store": "2.21.3",
-        "@liff/sub-window": "2.21.3",
-        "@liff/types": "2.21.3",
-        "@liff/use": "2.21.3",
-        "@liff/util": "2.21.3"
+        "@liff/check-availability": "2.22.2",
+        "@liff/close-window": "2.22.2",
+        "@liff/consts": "2.22.2",
+        "@liff/extensions": "2.22.2",
+        "@liff/get-line-version": "2.22.2",
+        "@liff/get-os": "2.22.2",
+        "@liff/hooks": "2.22.2",
+        "@liff/i18n": "2.22.2",
+        "@liff/is-api-available": "2.22.2",
+        "@liff/is-in-client": "2.22.2",
+        "@liff/is-logged-in": "2.22.2",
+        "@liff/is-sub-window": "2.22.2",
+        "@liff/logger": "2.22.2",
+        "@liff/login": "2.22.2",
+        "@liff/logout": "2.22.2",
+        "@liff/message-bus": "2.22.2",
+        "@liff/native-bridge": "2.22.2",
+        "@liff/ready": "2.22.2",
+        "@liff/server-api": "2.22.2",
+        "@liff/store": "2.22.2",
+        "@liff/sub-window": "2.22.2",
+        "@liff/types": "2.22.2",
+        "@liff/use": "2.22.2",
+        "@liff/util": "2.22.2"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/is-api-available": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/is-api-available/-/is-api-available-2.21.3.tgz",
-      "integrity": "sha512-V6MYuSTLgkWQuVKLugW1cd8F1owgv5iklnTN8idcqrmCawTmSly/DBZFxlVcixPvaUUCk5gIIwx8czCGzfkniQ==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/is-api-available/-/is-api-available-2.22.2.tgz",
+      "integrity": "sha512-/15yBskA/uM4OnTt3Ca3lWPgHArYztEL+geMgQOLhYpFvorjyaREynllbpc4cUL5qACM+JfiN4T5frtzS/Sbsw==",
       "dev": true,
       "dependencies": {
-        "@liff/consts": "2.21.3",
-        "@liff/get-line-version": "2.21.3",
-        "@liff/is-in-client": "2.21.3",
-        "@liff/is-logged-in": "2.21.3",
-        "@liff/store": "2.21.3",
-        "@liff/util": "2.21.3"
+        "@liff/consts": "2.22.2",
+        "@liff/get-line-version": "2.22.2",
+        "@liff/is-in-client": "2.22.2",
+        "@liff/is-logged-in": "2.22.2",
+        "@liff/is-sub-window": "2.22.2",
+        "@liff/store": "2.22.2",
+        "@liff/use": "2.22.2",
+        "@liff/util": "2.22.2"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/is-in-client": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/is-in-client/-/is-in-client-2.21.3.tgz",
-      "integrity": "sha512-X6pb9z9KmlTSL62+TzHi88Q0K7TvVW78T+/SnYi/6sRrcayokwBT/Y34kS3STXB5lHeTNodLm1aDVCFciUlTDA==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/is-in-client/-/is-in-client-2.22.2.tgz",
+      "integrity": "sha512-ovh/9VgSiTooyE9YsEokyW/4bCrULbrbjIXtFZn2NNyPQqjMMeiaZxx1nn8RDRhE82rxYO39/SC3tieSWU7fYg==",
       "dev": true,
       "dependencies": {
-        "@liff/consts": "2.21.3",
-        "@liff/util": "2.21.3"
+        "@liff/consts": "2.22.2",
+        "@liff/use": "2.22.2",
+        "@liff/util": "2.22.2"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/is-logged-in": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/is-logged-in/-/is-logged-in-2.21.3.tgz",
-      "integrity": "sha512-s5Hg5YeW4ENv3M0Dvfw5oajcfa4BhqSKRI6JMXyoUw2j3hmIKCPCUQbOH97MiRSojiwdC4MMyReDqHFM7nskug==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/is-logged-in/-/is-logged-in-2.22.2.tgz",
+      "integrity": "sha512-nyr5Cq4PSMMjIIdcSkzcb7g2YeRnM3LO+ih1XTg1k3qkz0quXchUMpKM4CBqK6J9JKwjcXKQQlU0g5taBQtGAA==",
       "dev": true,
       "dependencies": {
-        "@liff/store": "2.21.3"
+        "@liff/store": "2.22.2",
+        "@liff/use": "2.22.2"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/is-sub-window": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/is-sub-window/-/is-sub-window-2.21.3.tgz",
-      "integrity": "sha512-tsFML2gF23v1+it8T4XFDGl8fofniOvUjSINaEryruPmhGpUlTQ1UA51isF9cvbp4KocwpuH24S/wj9xaOic4Q==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/is-sub-window/-/is-sub-window-2.22.2.tgz",
+      "integrity": "sha512-c3BNZPexkxwndRkXx5gestpqFjnL4VbvIWWmgv3JZaeuyBjFOpoUeBWC0+W3Hah6A/KVgoW/pq2MW3XqFWQrHA==",
       "dev": true,
       "dependencies": {
-        "@liff/consts": "2.21.3",
-        "@liff/is-in-client": "2.21.3",
-        "@liff/store": "2.21.3",
-        "@liff/use": "2.21.3",
-        "@liff/util": "2.21.3"
+        "@liff/consts": "2.22.2",
+        "@liff/is-in-client": "2.22.2",
+        "@liff/store": "2.22.2",
+        "@liff/use": "2.22.2",
+        "@liff/util": "2.22.2"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/liff-types": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/liff-types/-/liff-types-2.21.3.tgz",
-      "integrity": "sha512-WcqzMpgz/IMVmtkDuwc+L5qKW9v2iJOFBWuuWhsa5m/pSkOfnJMXxt/YHuNBWRNSQhMdRyyTspT0ByS7fWLUsg==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/liff-types/-/liff-types-2.22.2.tgz",
+      "integrity": "sha512-5vs/EvQQIw6OBjWa8RoHTcvZK46XpXtnMWndzLWH39DbqqaoMMggNNIRtJGhJJvHa1AWCXPmkJ6ykv5HRJMdHA==",
       "dev": true,
       "dependencies": {
-        "@liff/analytics": "2.21.3",
-        "@liff/close-window": "2.21.3",
-        "@liff/get-friendship": "2.21.3",
-        "@liff/get-language": "2.21.3",
-        "@liff/get-line-version": "2.21.3",
-        "@liff/get-os": "2.21.3",
-        "@liff/get-profile": "2.21.3",
-        "@liff/get-version": "2.21.3",
-        "@liff/i18n": "2.21.3",
-        "@liff/init": "2.21.3",
-        "@liff/is-api-available": "2.21.3",
-        "@liff/is-in-client": "2.21.3",
-        "@liff/is-logged-in": "2.21.3",
-        "@liff/is-sub-window": "2.21.3",
-        "@liff/login": "2.21.3",
-        "@liff/logout": "2.21.3",
-        "@liff/native-bridge": "2.21.3",
-        "@liff/open-window": "2.21.3",
-        "@liff/permanent-link": "2.21.3",
-        "@liff/permission": "2.21.3",
-        "@liff/ready": "2.21.3",
-        "@liff/scan-code-v2": "2.21.3",
-        "@liff/send-messages": "2.21.3",
-        "@liff/share-target-picker": "2.21.3",
-        "@liff/store": "2.21.3",
-        "@liff/sub-window": "2.21.3",
-        "@liff/use": "2.21.3"
+        "@liff/analytics": "2.22.2",
+        "@liff/close-window": "2.22.2",
+        "@liff/get-friendship": "2.22.2",
+        "@liff/get-language": "2.22.2",
+        "@liff/get-line-version": "2.22.2",
+        "@liff/get-os": "2.22.2",
+        "@liff/get-profile": "2.22.2",
+        "@liff/get-version": "2.22.2",
+        "@liff/i18n": "2.22.2",
+        "@liff/init": "2.22.2",
+        "@liff/is-api-available": "2.22.2",
+        "@liff/is-in-client": "2.22.2",
+        "@liff/is-logged-in": "2.22.2",
+        "@liff/is-sub-window": "2.22.2",
+        "@liff/login": "2.22.2",
+        "@liff/logout": "2.22.2",
+        "@liff/native-bridge": "2.22.2",
+        "@liff/open-window": "2.22.2",
+        "@liff/permanent-link": "2.22.2",
+        "@liff/permission": "2.22.2",
+        "@liff/ready": "2.22.2",
+        "@liff/scan-code-v2": "2.22.2",
+        "@liff/send-messages": "2.22.2",
+        "@liff/share-target-picker": "2.22.2",
+        "@liff/store": "2.22.2",
+        "@liff/sub-window": "2.22.2",
+        "@liff/use": "2.22.2"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/logger": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/logger/-/logger-2.21.3.tgz",
-      "integrity": "sha512-Jho+01e6naJChEzsLtzNptfLOLQtvIQlHH8rO5mnG3VvtU4kgSacVVn9FhaSIVfkVYtifCLP2vHmJ55++I0KJA==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/logger/-/logger-2.22.2.tgz",
+      "integrity": "sha512-F4AGX3YUrUyKFyn0ITMa7RwUN2ccyngucCHKnLZ5rA2Ospj9WFRD9Ytb/ijXlDi+DCbaVNDsY8vatwRfDxQiXQ==",
       "dev": true,
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/login": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/login/-/login-2.21.3.tgz",
-      "integrity": "sha512-5+mO3FVCGhcEq8dCwzEEvEBJuIImo3x6aIyXu9vXAkjm/Q3nqNprSBPVtPeey7z0qMmMkFxfNFf0L17sczPGTQ==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/login/-/login-2.22.2.tgz",
+      "integrity": "sha512-s7SZHKrCS9VK5GMbbpsIZKRxHQF8PKM6zNCwyHa3njJhEbRzsOkDLTfypicmulfqs/OMrXVmd1ZPya1FvV0vgw==",
       "dev": true,
       "dependencies": {
-        "@liff/consts": "2.21.3",
-        "@liff/get-version": "2.21.3",
-        "@liff/hooks": "2.21.3",
-        "@liff/is-in-client": "2.21.3",
-        "@liff/is-sub-window": "2.21.3",
-        "@liff/logger": "2.21.3",
-        "@liff/server-api": "2.21.3",
-        "@liff/store": "2.21.3",
-        "@liff/sub-window": "2.21.3",
-        "@liff/use": "2.21.3",
-        "@liff/util": "2.21.3",
+        "@liff/consts": "2.22.2",
+        "@liff/get-version": "2.22.2",
+        "@liff/hooks": "2.22.2",
+        "@liff/is-in-client": "2.22.2",
+        "@liff/is-sub-window": "2.22.2",
+        "@liff/logger": "2.22.2",
+        "@liff/server-api": "2.22.2",
+        "@liff/store": "2.22.2",
+        "@liff/sub-window": "2.22.2",
+        "@liff/use": "2.22.2",
+        "@liff/util": "2.22.2",
         "tiny-sha256": "^1.0.2"
       },
       "peerDependencies": {
@@ -1337,149 +1374,152 @@
       }
     },
     "node_modules/@liff/logout": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/logout/-/logout-2.21.3.tgz",
-      "integrity": "sha512-OYu11KurMh7FWn9aWt8VXGaCKHaVjJdMOjp7uGZx9NSOOppSJ+QJQ/m3L091auNmNKGz2cJkO3ywzpZcGcYPTA==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/logout/-/logout-2.22.2.tgz",
+      "integrity": "sha512-fcPbPPwSqtjGKLtTx/GBPukQOYarSbDZ7XLwg+bADzwJUOPm+cCKIVLkTBWwOi/Ahpm+p6mP133uPfa3sFuj+g==",
       "dev": true,
       "dependencies": {
-        "@liff/store": "2.21.3"
+        "@liff/store": "2.22.2",
+        "@liff/use": "2.22.2"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/message-bus": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/message-bus/-/message-bus-2.21.3.tgz",
-      "integrity": "sha512-1AtuOs/7PFE2gFb0z2XmF+nMIt3K4X9x1irSZ3yOarfuFvZgCuaEAxRnOWmWhUKgTllYNmvDGjLrd/bqOQvFWg==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/message-bus/-/message-bus-2.22.2.tgz",
+      "integrity": "sha512-IhK4MQ99atJxZWsPAo4lmgM52fhneODZRxLAwljVnU6xkVThYFeqmkMO3WLxZUulYLsvKIW/EwCh+EXZUzP7Sw==",
       "dev": true,
       "dependencies": {
-        "@liff/consts": "2.21.3",
-        "@liff/store": "2.21.3",
-        "@liff/util": "2.21.3"
+        "@liff/consts": "2.22.2",
+        "@liff/store": "2.22.2",
+        "@liff/util": "2.22.2"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/native-bridge": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/native-bridge/-/native-bridge-2.21.3.tgz",
-      "integrity": "sha512-+knPCl0pALmhC1Ng+RB25tblLemgw+kwZQR83dAJyrU8uSjGKt8zeo9C0TTfF8nRKcKajc/6E7EwO0iLClLHQA==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/native-bridge/-/native-bridge-2.22.2.tgz",
+      "integrity": "sha512-qhY9nHdYQUKFrH7137tVYAMKbxAl68iDpdOGgY4RezGz3OcHEVtSCczw03JCNj1SoVphQVaxCcUpwvRbLWjTtg==",
       "dev": true,
       "dependencies": {
-        "@liff/consts": "2.21.3",
-        "@liff/logger": "2.21.3",
-        "@liff/store": "2.21.3",
-        "@liff/util": "2.21.3"
+        "@liff/consts": "2.22.2",
+        "@liff/logger": "2.22.2",
+        "@liff/store": "2.22.2",
+        "@liff/types": "2.22.2",
+        "@liff/util": "2.22.2"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/open-window": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/open-window/-/open-window-2.21.3.tgz",
-      "integrity": "sha512-r0/wLewUh5uO/0lPasuQ+ZzNLVW7Z8MATEY2A/gZz6ap1R+r0HFK7grJqq+h52puYyy0Sqe2kpkMMt6CAmt2lg==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/open-window/-/open-window-2.22.2.tgz",
+      "integrity": "sha512-Rs5tzNq1o5wG19iwOW4PCYTxtq0pkuzbzXiA8iLzEzpAb+YOQFB5TrDjwVyCL5WZhvytU2wsfKsafHCk2Q4lBg==",
       "dev": true,
       "dependencies": {
-        "@liff/consts": "2.21.3",
-        "@liff/get-line-version": "2.21.3",
-        "@liff/get-os": "2.21.3",
-        "@liff/is-in-client": "2.21.3",
-        "@liff/native-bridge": "2.21.3",
-        "@liff/util": "2.21.3"
+        "@liff/consts": "2.22.2",
+        "@liff/get-line-version": "2.22.2",
+        "@liff/get-os": "2.22.2",
+        "@liff/is-in-client": "2.22.2",
+        "@liff/native-bridge": "2.22.2",
+        "@liff/types": "2.22.2",
+        "@liff/use": "2.22.2",
+        "@liff/util": "2.22.2"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/permanent-link": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/permanent-link/-/permanent-link-2.21.3.tgz",
-      "integrity": "sha512-j+NZBWV3/v6tBmWEwpYUfKkbyc7eYR1O854w16OduFtC2d3tunLkH6p+UMg+sic1l+GrtUA6K/Xi3UG/JF+fZw==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/permanent-link/-/permanent-link-2.22.2.tgz",
+      "integrity": "sha512-K7qFlV27eF4D5cuYTyF5Edld0Djff6n3SqlJtq196QYIg5KP5cx6Ey+VnocvbFbRKzUILd9Wo4yJy7er30YrMQ==",
       "dev": true,
       "dependencies": {
-        "@liff/consts": "2.21.3",
-        "@liff/server-api": "2.21.3",
-        "@liff/store": "2.21.3",
-        "@liff/use": "2.21.3",
-        "@liff/util": "2.21.3"
+        "@liff/consts": "2.22.2",
+        "@liff/server-api": "2.22.2",
+        "@liff/store": "2.22.2",
+        "@liff/use": "2.22.2",
+        "@liff/util": "2.22.2"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/permission": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/permission/-/permission-2.21.3.tgz",
-      "integrity": "sha512-U5Dr23pQjLIxgr+YlcdkgjOeiRoyn2rINPMplXRY4DgYaGkC0RJmm9y+V8rTIDPsrtG25SHApT5qRG6tNu9LDA==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/permission/-/permission-2.22.2.tgz",
+      "integrity": "sha512-FoT+x07juIZjv5onx/i/ADSq7Hye7i0fR9kP3fNPi7XELtWhGnveCGUGF7eA4psk5lAphsJmw5yLWT1AnnJH9A==",
       "dev": true,
       "dependencies": {
-        "@liff/consts": "2.21.3",
-        "@liff/is-api-available": "2.21.3",
-        "@liff/is-in-client": "2.21.3",
-        "@liff/server-api": "2.21.3",
-        "@liff/store": "2.21.3",
-        "@liff/sub-window": "2.21.3",
-        "@liff/use": "2.21.3",
-        "@liff/util": "2.21.3"
+        "@liff/consts": "2.22.2",
+        "@liff/is-api-available": "2.22.2",
+        "@liff/is-in-client": "2.22.2",
+        "@liff/server-api": "2.22.2",
+        "@liff/store": "2.22.2",
+        "@liff/sub-window": "2.22.2",
+        "@liff/use": "2.22.2",
+        "@liff/util": "2.22.2"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/ready": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/ready/-/ready-2.21.3.tgz",
-      "integrity": "sha512-pkn9zD84d2h090WctchOjRiYrOoa0oWvQja0f1KXnqxyCqrowwG31fyuXsONG3dzzrzHdUAuo9VGZXgjL0RROQ==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/ready/-/ready-2.22.2.tgz",
+      "integrity": "sha512-2kdlH9KAdHkX/XU/0nsZ5kPSc2Z3aKN+rNusBsRWrGIwR9iRAnYkLP/kMr2UXIeloHTxwNNUSUCkJV58t/mTIw==",
       "dev": true,
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/scan-code": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/scan-code/-/scan-code-2.21.3.tgz",
-      "integrity": "sha512-C1eF8liy/z89JfKcV91Y14AVtDEZ6l/YpdJB14k1uNIJGQeIt6dKs7rsJ7W5aulhV3E87f7j6OVrfl0liAOsUQ==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/scan-code/-/scan-code-2.22.2.tgz",
+      "integrity": "sha512-irsDX4JnIsbqIx9epbLJyX6qfXEmVqelTUmOown4XDFpasq5TMaqXWPjauNljPwWrAOHM79Vus4fRMQYnIJp0Q==",
       "dev": true,
       "dependencies": {
-        "@liff/check-availability": "2.21.3",
-        "@liff/consts": "2.21.3",
-        "@liff/native-bridge": "2.21.3",
-        "@liff/util": "2.21.3"
+        "@liff/types": "2.22.2"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/scan-code-v2": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/scan-code-v2/-/scan-code-v2-2.21.3.tgz",
-      "integrity": "sha512-Cq3xe3ITAgR0GeJokoFX4dXuIc37eIGQt2AdAnxgk6oduqVUt0VxhG3kDaTtEC/qY6N9AFoQfFv69FJjmVAhRQ==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/scan-code-v2/-/scan-code-v2-2.22.2.tgz",
+      "integrity": "sha512-8PzRlWKhtFzHjvasv/ToZSqDIZYeOaNc6iEhrUJDIvNcyoCZkjT11lFAuEjkjxelY1z+ZBDjnQ4TVl0AJHFKjg==",
       "dev": true,
       "dependencies": {
-        "@liff/consts": "2.21.3",
-        "@liff/is-api-available": "2.21.3",
-        "@liff/sub-window": "2.21.3",
-        "@liff/use": "2.21.3",
-        "@liff/util": "2.21.3"
+        "@liff/consts": "2.22.2",
+        "@liff/is-api-available": "2.22.2",
+        "@liff/sub-window": "2.22.2",
+        "@liff/use": "2.22.2",
+        "@liff/util": "2.22.2"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/send-messages": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/send-messages/-/send-messages-2.21.3.tgz",
-      "integrity": "sha512-URY0NCbBOXap4wTAcFadIGhYoRHR/qWGQWxBptAsDS9ZHk8wvnZzaNd0MZI3NkfkaCxRJbhpeIlBM2QQHE/48g==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/send-messages/-/send-messages-2.22.2.tgz",
+      "integrity": "sha512-qaquONL9Ag9dnrBf6KfI5KFtkkW3T7y00dNCZddgbf5WitNUJ1fEjuHr2HHEXTF6H6v3JusIXxUrIhBnwzP6yQ==",
       "dev": true,
       "dependencies": {
-        "@liff/consts": "2.21.3",
-        "@liff/get-line-version": "2.21.3",
-        "@liff/get-os": "2.21.3",
-        "@liff/server-api": "2.21.3",
-        "@liff/util": "2.21.3",
+        "@liff/consts": "2.22.2",
+        "@liff/get-line-version": "2.22.2",
+        "@liff/get-os": "2.22.2",
+        "@liff/permission": "2.22.2",
+        "@liff/server-api": "2.22.2",
+        "@liff/use": "2.22.2",
+        "@liff/util": "2.22.2",
         "@line/bot-sdk": "^7.0.0"
       },
       "peerDependencies": {
@@ -1487,123 +1527,126 @@
       }
     },
     "node_modules/@liff/server-api": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/server-api/-/server-api-2.21.3.tgz",
-      "integrity": "sha512-svsYws90xLCqodYMhjdiWlESfN5OKDJwvKl9pnE+3HRKvXAK0ize0CZWJMCEPXkyay9eGJsWc8wTlO7rkM4brg==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/server-api/-/server-api-2.22.2.tgz",
+      "integrity": "sha512-5VWu4+mXAj+XV3WOw63z/M4krC6pOD8gt7Y/primouBZO4uFdNTSu/UP7th023EWn+FOZ4i5OhIx4hMEUDB6zw==",
       "dev": true,
       "dependencies": {
-        "@liff/consts": "2.21.3",
-        "@liff/store": "2.21.3",
-        "@liff/util": "2.21.3"
+        "@liff/consts": "2.22.2",
+        "@liff/store": "2.22.2",
+        "@liff/util": "2.22.2"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/share-target-picker": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/share-target-picker/-/share-target-picker-2.21.3.tgz",
-      "integrity": "sha512-RbgM5jfK9wUth/GDRLRT/hsWYfOsXcKSjSZho0jsUhzGrIBWoMrEPZTOZASgN+9WtwosarCxZLiKwFoK/AWOdA==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/share-target-picker/-/share-target-picker-2.22.2.tgz",
+      "integrity": "sha512-385drTUsFCKhaow0YkYiOJHZNohtNC+SXp6JD5wzLX1w50dlGfpewuOESSGhfEvdvNk0JiM4rF3tb8tdEZUlgQ==",
       "dev": true,
       "dependencies": {
-        "@liff/analytics": "2.21.3",
-        "@liff/consts": "2.21.3",
-        "@liff/get-line-version": "2.21.3",
-        "@liff/get-os": "2.21.3",
-        "@liff/is-in-client": "2.21.3",
-        "@liff/is-logged-in": "2.21.3",
-        "@liff/is-sub-window": "2.21.3",
-        "@liff/logger": "2.21.3",
-        "@liff/send-messages": "2.21.3",
-        "@liff/server-api": "2.21.3",
-        "@liff/store": "2.21.3",
-        "@liff/types": "2.21.3",
-        "@liff/use": "2.21.3",
-        "@liff/util": "2.21.3",
-        "@liff/window-postmessage": "2.21.3"
+        "@liff/analytics": "2.22.2",
+        "@liff/consts": "2.22.2",
+        "@liff/get-line-version": "2.22.2",
+        "@liff/get-os": "2.22.2",
+        "@liff/is-api-available": "2.22.2",
+        "@liff/is-in-client": "2.22.2",
+        "@liff/is-logged-in": "2.22.2",
+        "@liff/is-sub-window": "2.22.2",
+        "@liff/logger": "2.22.2",
+        "@liff/send-messages": "2.22.2",
+        "@liff/server-api": "2.22.2",
+        "@liff/store": "2.22.2",
+        "@liff/types": "2.22.2",
+        "@liff/use": "2.22.2",
+        "@liff/util": "2.22.2",
+        "@liff/window-postmessage": "2.22.2"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/store": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/store/-/store-2.21.3.tgz",
-      "integrity": "sha512-bMs6Ur4dkfm4JQbdMqKHzT/pz+P62vVT5+xXLbmxSvJtXxKenmizpwzuNLTRKbzugfyEX+vJZ+EsktFHBZYCuQ==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/store/-/store-2.22.2.tgz",
+      "integrity": "sha512-Zjixe2vbF5effVI+Bd/PlV8aQyHVwrSKt+86fh8SwHXvA7dwiXq3d2o8alu4anPHIGb0Z0uCsLx92wW6EyCuZw==",
       "dev": true,
       "dependencies": {
-        "@liff/consts": "2.21.3",
-        "@liff/is-in-client": "2.21.3",
-        "@liff/types": "2.21.3",
-        "@liff/util": "2.21.3"
+        "@liff/consts": "2.22.2",
+        "@liff/is-in-client": "2.22.2",
+        "@liff/types": "2.22.2",
+        "@liff/use": "2.22.2",
+        "@liff/util": "2.22.2"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/sub-window": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/sub-window/-/sub-window-2.21.3.tgz",
-      "integrity": "sha512-WWWW6LtsYZ8/slvvUGUfSkaBk/GTgqXqEYyqk3mYSeTs/vvLJYRzi6tLJVKtBmeIWrQcxXCOBGnQaIMEWGbXew==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/sub-window/-/sub-window-2.22.2.tgz",
+      "integrity": "sha512-z44+hpgFIV9WTf5qqpcUbKet65mRjGSJw+HBRSjp1BFTSCSrO5wFrDG0VU43Qb+6UA36pbl9/iirb2J0j/itUA==",
       "dev": true,
       "dependencies": {
-        "@liff/close-window": "2.21.3",
-        "@liff/consts": "2.21.3",
-        "@liff/get-os": "2.21.3",
-        "@liff/is-api-available": "2.21.3",
-        "@liff/is-in-client": "2.21.3",
-        "@liff/is-sub-window": "2.21.3",
-        "@liff/logger": "2.21.3",
-        "@liff/message-bus": "2.21.3",
-        "@liff/server-api": "2.21.3",
-        "@liff/store": "2.21.3",
-        "@liff/util": "2.21.3"
+        "@liff/close-window": "2.22.2",
+        "@liff/consts": "2.22.2",
+        "@liff/get-os": "2.22.2",
+        "@liff/is-api-available": "2.22.2",
+        "@liff/is-in-client": "2.22.2",
+        "@liff/is-sub-window": "2.22.2",
+        "@liff/logger": "2.22.2",
+        "@liff/message-bus": "2.22.2",
+        "@liff/server-api": "2.22.2",
+        "@liff/store": "2.22.2",
+        "@liff/use": "2.22.2",
+        "@liff/util": "2.22.2"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/types": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/types/-/types-2.21.3.tgz",
-      "integrity": "sha512-YuQXAYi7WQTtUb7MCziszJpknFq3jSHEP/Uc1CfUiFaC/fYr9p3+2WC15FJ+OYl2XrcKqAi9pDrw/P1c81ygVQ==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/types/-/types-2.22.2.tgz",
+      "integrity": "sha512-wFFy6U93U9Bc6wMTLRrkonbCsfTT5YsCeCuov4N5Wbx7cAugkp9fdDuIzIQ7oScItKxm2Qhv+LR72x/mDcgN4w==",
       "dev": true
     },
     "node_modules/@liff/use": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/use/-/use-2.21.3.tgz",
-      "integrity": "sha512-XegeLHVZZfOaHxkHuRZvVDhh26COuInnpbRo1gz1PQzrBUFpZNCG4t/mLli0z2go9D66g1dHokq6PE1zuoZvpA==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/use/-/use-2.22.2.tgz",
+      "integrity": "sha512-9XluXhVXn92dCXAvI/jAmUJXelVheZMkNI0tvntvgEghQSJBvQw9T9SmjgK8nysEbC9DMM2clgdpwM2z7G/acA==",
       "dev": true,
       "dependencies": {
-        "@liff/hooks": "2.21.3",
-        "@liff/logger": "2.21.3"
+        "@liff/hooks": "2.22.2",
+        "@liff/logger": "2.22.2"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/util": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/util/-/util-2.21.3.tgz",
-      "integrity": "sha512-45U9o2sBC4hxFFb9ghOmygOpwRw6Qxfc3/PbZmB17qqVRBzu0+0b1IkSQg0kVWcQnQF8+AtwtihjCYfbbpJgxA==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/util/-/util-2.22.2.tgz",
+      "integrity": "sha512-HTZCwr/ni+1AAZQ2eJB7wBuDD+6x9UbZy2l/AQZ9+B6m7+Q50haVUOa1ujnFduA9TA5Wy8DrrVWiCDk5XRq5KQ==",
       "dev": true,
       "dependencies": {
-        "@liff/consts": "2.21.3",
-        "@liff/logger": "2.21.3"
+        "@liff/consts": "2.22.2",
+        "@liff/logger": "2.22.2"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/window-postmessage": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/window-postmessage/-/window-postmessage-2.21.3.tgz",
-      "integrity": "sha512-NtIpc+H0Dc130bUsJ/sOcUjKsvF2J85mfjJQ57Z4bkz+VjX9AsJgzZIUAccfvKSRMdOiGM1KNIt5rUD/iIMi4w==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/window-postmessage/-/window-postmessage-2.22.2.tgz",
+      "integrity": "sha512-b6woZiEIDRoonhUtP9NVpxG9hbumDQRJa0Z0crG6N/1uPrBoglFEpuaOeCcujWuyL5Eqvmh0jXB3pCp/Zvc4Mw==",
       "dev": true,
       "dependencies": {
-        "@liff/consts": "2.21.3",
-        "@liff/logger": "2.21.3",
-        "@liff/util": "2.21.3"
+        "@liff/consts": "2.22.2",
+        "@liff/logger": "2.22.2",
+        "@liff/util": "2.22.2"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
@@ -1641,45 +1684,45 @@
       }
     },
     "node_modules/@line/liff": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@line/liff/-/liff-2.21.3.tgz",
-      "integrity": "sha512-OGUPooaZlfKmResRZCJzxp5v8WLYZHnRSwwRc7NO3xm8tm0dG965L6siBUSxm2aH0FdqKw+dyWQvGoHyF4EjIQ==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@line/liff/-/liff-2.22.2.tgz",
+      "integrity": "sha512-2qWOlf3DPZJFIh6BlvbxBC8jp8U81cx36go8LLMHTzXj4PppXtlmwMJ44ZLF1kyPvJBefVMew9qVq2Cg/sSDAA==",
       "dev": true,
       "dependencies": {
-        "@liff/analytics": "2.21.3",
-        "@liff/close-window": "2.21.3",
-        "@liff/consts": "2.21.3",
-        "@liff/extensions": "2.21.3",
-        "@liff/get-friendship": "2.21.3",
-        "@liff/get-language": "2.21.3",
-        "@liff/get-line-version": "2.21.3",
-        "@liff/get-os": "2.21.3",
-        "@liff/get-profile": "2.21.3",
-        "@liff/get-version": "2.21.3",
-        "@liff/hooks": "2.21.3",
-        "@liff/i18n": "2.21.3",
-        "@liff/init": "2.21.3",
-        "@liff/is-api-available": "2.21.3",
-        "@liff/is-in-client": "2.21.3",
-        "@liff/is-logged-in": "2.21.3",
-        "@liff/is-sub-window": "2.21.3",
-        "@liff/liff-types": "2.21.3",
-        "@liff/login": "2.21.3",
-        "@liff/logout": "2.21.3",
-        "@liff/native-bridge": "2.21.3",
-        "@liff/open-window": "2.21.3",
-        "@liff/permanent-link": "2.21.3",
-        "@liff/permission": "2.21.3",
-        "@liff/ready": "2.21.3",
-        "@liff/scan-code-v2": "2.21.3",
-        "@liff/send-messages": "2.21.3",
-        "@liff/server-api": "2.21.3",
-        "@liff/share-target-picker": "2.21.3",
-        "@liff/store": "2.21.3",
-        "@liff/sub-window": "2.21.3",
-        "@liff/use": "2.21.3",
-        "@liff/util": "2.21.3",
-        "promise-polyfill": "^8.1.3",
+        "@liff/analytics": "2.22.2",
+        "@liff/close-window": "2.22.2",
+        "@liff/consts": "2.22.2",
+        "@liff/core": "2.22.2",
+        "@liff/extensions": "2.22.2",
+        "@liff/get-friendship": "2.22.2",
+        "@liff/get-language": "2.22.2",
+        "@liff/get-line-version": "2.22.2",
+        "@liff/get-os": "2.22.2",
+        "@liff/get-profile": "2.22.2",
+        "@liff/get-version": "2.22.2",
+        "@liff/hooks": "2.22.2",
+        "@liff/i18n": "2.22.2",
+        "@liff/init": "2.22.2",
+        "@liff/is-api-available": "2.22.2",
+        "@liff/is-in-client": "2.22.2",
+        "@liff/is-logged-in": "2.22.2",
+        "@liff/is-sub-window": "2.22.2",
+        "@liff/liff-types": "2.22.2",
+        "@liff/login": "2.22.2",
+        "@liff/logout": "2.22.2",
+        "@liff/native-bridge": "2.22.2",
+        "@liff/open-window": "2.22.2",
+        "@liff/permanent-link": "2.22.2",
+        "@liff/permission": "2.22.2",
+        "@liff/ready": "2.22.2",
+        "@liff/scan-code-v2": "2.22.2",
+        "@liff/send-messages": "2.22.2",
+        "@liff/server-api": "2.22.2",
+        "@liff/share-target-picker": "2.22.2",
+        "@liff/store": "2.22.2",
+        "@liff/sub-window": "2.22.2",
+        "@liff/use": "2.22.2",
+        "@liff/util": "2.22.2",
         "tslib": "^2.3.0",
         "whatwg-fetch": "^3.0.0"
       }
@@ -2816,13 +2859,13 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
-      "integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
+      "version": "1.20.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
+      "integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
       "dev": true,
       "dependencies": {
         "bytes": "3.1.2",
-        "content-type": "~1.0.4",
+        "content-type": "~1.0.5",
         "debug": "2.6.9",
         "depd": "2.0.0",
         "destroy": "1.2.0",
@@ -2830,7 +2873,7 @@
         "iconv-lite": "0.4.24",
         "on-finished": "2.4.1",
         "qs": "6.11.0",
-        "raw-body": "2.5.1",
+        "raw-body": "2.5.2",
         "type-is": "~1.6.18",
         "unpipe": "1.0.0"
       },
@@ -3276,9 +3319,9 @@
       ]
     },
     "node_modules/content-type": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
       "dev": true,
       "engines": {
         "node": ">= 0.6"
@@ -4521,13 +4564,14 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
-      "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
+      "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
       "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
+        "has-proto": "^1.0.1",
         "has-symbols": "^1.0.3"
       },
       "funding": {
@@ -4659,6 +4703,18 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
+      "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/has-symbols": {
@@ -6295,9 +6351,9 @@
       "dev": true
     },
     "node_modules/object-inspect": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
-      "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
+      "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6661,12 +6717,6 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
     },
-    "node_modules/promise-polyfill": {
-      "version": "8.2.3",
-      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.2.3.tgz",
-      "integrity": "sha512-Og0+jCRQetV84U8wVjMNccfGCnMQ9mGs9Hv78QFe+pSDD3gWTpz0y+1QCuxy5d/vBFuZ3iwP2eycAkvqIMPmWg==",
-      "dev": true
-    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -6771,9 +6821,9 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
-      "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
       "dev": true,
       "dependencies": {
         "bytes": "3.1.2",
@@ -7862,9 +7912,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+      "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
       "dev": true
     },
     "node_modules/tsutils": {
@@ -9373,522 +9423,558 @@
       "dev": true
     },
     "@liff/add-to-home-screen": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/add-to-home-screen/-/add-to-home-screen-2.21.3.tgz",
-      "integrity": "sha512-KWbEXr/H4uDWH2jTt2jYG36KuxrL0laiJ93VG0fELW3JoWMFAisQMoLiIXe/I5NkT4nZlr3g0vN1nG7bKHX15A==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/add-to-home-screen/-/add-to-home-screen-2.22.2.tgz",
+      "integrity": "sha512-KyL3DAtRtt8gf3irS3zAGpnSkqkc75EDQEIVajWh1FRwrKy/oS6sgfl6Gcjac7Jq2DOLUkwN1DA15fBuBpWdWw==",
       "dev": true,
       "requires": {
-        "@liff/check-availability": "2.21.3",
-        "@liff/consts": "2.21.3",
-        "@liff/is-in-client": "2.21.3",
-        "@liff/is-sub-window": "2.21.3",
-        "@liff/native-bridge": "2.21.3",
-        "@liff/open-window": "2.21.3",
-        "@liff/util": "2.21.3"
+        "@liff/consts": "2.22.2",
+        "@liff/open-window": "2.22.2",
+        "@liff/types": "2.22.2",
+        "@liff/util": "2.22.2"
       }
     },
     "@liff/analytics": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/analytics/-/analytics-2.21.3.tgz",
-      "integrity": "sha512-yPTzG3ekBDQUNRtAbZZSMfviMjJ9MDPNABTwWPTBSQ1msyxvQ8QffZBhmaeLp7Q21379SH7wRJj05iZixX2Lng==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/analytics/-/analytics-2.22.2.tgz",
+      "integrity": "sha512-wFk3VpmZSmOtDHKeU9jvn/VRhioCxpaO9r9kXXMo8znpg6PaP/0gGAIWEJxEF6GWhSE+GbAgHZYE+E4i5I1V0g==",
       "dev": true,
       "requires": {
-        "@liff/consts": "2.21.3",
-        "@liff/get-profile": "2.21.3",
-        "@liff/get-version": "2.21.3",
-        "@liff/is-logged-in": "2.21.3",
-        "@liff/logger": "2.21.3",
-        "@liff/store": "2.21.3",
-        "@liff/types": "2.21.3",
-        "@liff/use": "2.21.3",
-        "@liff/util": "2.21.3"
+        "@liff/consts": "2.22.2",
+        "@liff/core": "2.22.2",
+        "@liff/get-profile": "2.22.2",
+        "@liff/get-version": "2.22.2",
+        "@liff/is-logged-in": "2.22.2",
+        "@liff/logger": "2.22.2",
+        "@liff/store": "2.22.2",
+        "@liff/types": "2.22.2",
+        "@liff/use": "2.22.2",
+        "@liff/util": "2.22.2"
       }
     },
     "@liff/check-availability": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/check-availability/-/check-availability-2.21.3.tgz",
-      "integrity": "sha512-BUyHWQ+B8+3EtWr9sBtrOV7M+GsKacyC0dwUskNBifWaoXg1IEqEX18O49NjoFYK5bb2tz3H/YDw+zRKJMfHgQ==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/check-availability/-/check-availability-2.22.2.tgz",
+      "integrity": "sha512-aD6PGWrFbst7IkiPMuCyZkpYKqSUUYRE5v6gcsnxT6wBBeKZbwjK15XjV5VTMq//LQYR9eu03MremKEyV44bLg==",
       "dev": true,
       "requires": {
-        "@liff/get-version": "2.21.3",
-        "@liff/is-api-available": "2.21.3",
-        "@liff/util": "2.21.3"
+        "@liff/get-version": "2.22.2",
+        "@liff/is-api-available": "2.22.2",
+        "@liff/types": "2.22.2",
+        "@liff/util": "2.22.2"
       }
     },
     "@liff/close-window": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/close-window/-/close-window-2.21.3.tgz",
-      "integrity": "sha512-4oaDLwrFw7icxyPlilOdGP2ZwJL/yioqcCWRfZT5IdYl/cy+ScCA+6uH6A9Y4F/M+9hUBghlVMXKCn2xuIBRww==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/close-window/-/close-window-2.22.2.tgz",
+      "integrity": "sha512-w0VozITe4MjQi3MfeTegnH3kt11U4E5JLMY9zM4vhxHJLXVD9g/Pvnp2NcKFN8BgraQFs9UF+NyfgRCknivhgA==",
       "dev": true,
       "requires": {
-        "@liff/get-line-version": "2.21.3",
-        "@liff/get-os": "2.21.3",
-        "@liff/native-bridge": "2.21.3",
-        "@liff/util": "2.21.3"
+        "@liff/get-line-version": "2.22.2",
+        "@liff/get-os": "2.22.2",
+        "@liff/native-bridge": "2.22.2",
+        "@liff/types": "2.22.2",
+        "@liff/use": "2.22.2",
+        "@liff/util": "2.22.2"
       }
     },
     "@liff/consts": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/consts/-/consts-2.21.3.tgz",
-      "integrity": "sha512-/EKhFKC2gNCg6+8bC6hCGcEX48Ec9PFuBJ6z4CPRtehVq/LtBNOEtdhwRvLgKmvrRj2aztTFHHNvXC2TC08cBA==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/consts/-/consts-2.22.2.tgz",
+      "integrity": "sha512-uqqOIsDNkW9HHF3dYOcI4Usud9UiEOVtx3TOHidZzFFfGLJy7Yx7oYCZVooKw2QBpHaOXFGpupN1CKzKbYUQWg==",
       "dev": true,
       "requires": {}
     },
-    "@liff/extensions": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/extensions/-/extensions-2.21.3.tgz",
-      "integrity": "sha512-soJkiFcTTMhRMvDhY2ravRWGq3cXUnLbPh4a/0AcRtR8LAu/rivcpXJj5LKNCite5TNDd4h7PWtbJNY64k9LwQ==",
+    "@liff/core": {
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/core/-/core-2.22.2.tgz",
+      "integrity": "sha512-rn1cXopCYWxON9rnybcX8PQxtn7S810OjMaV+4c6CJmF/POQU2h++z+A1ne1QI6YLjl918Hdu/sMYpgTfdUVaw==",
       "dev": true,
       "requires": {
-        "@liff/add-to-home-screen": "2.21.3",
-        "@liff/check-availability": "2.21.3",
-        "@liff/consts": "2.21.3",
-        "@liff/get-advertising-id": "2.21.3",
-        "@liff/get-line-version": "2.21.3",
-        "@liff/get-os": "2.21.3",
-        "@liff/logger": "2.21.3",
-        "@liff/scan-code": "2.21.3",
-        "@liff/store": "2.21.3",
-        "@liff/util": "2.21.3"
+        "@liff/get-version": "2.22.2",
+        "@liff/init": "2.22.2",
+        "@liff/native-bridge": "2.22.2",
+        "@liff/ready": "2.22.2",
+        "@liff/store": "2.22.2",
+        "@liff/use": "2.22.2"
+      }
+    },
+    "@liff/extensions": {
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/extensions/-/extensions-2.22.2.tgz",
+      "integrity": "sha512-8tRaJOMUnLadGXRPIPAqgHKBGqZ/5Th772Ga0dQ/7aGbrmw1oMCMTh0NRdGQ0F7MqNQsgSP4bocXDUDolqT2dw==",
+      "dev": true,
+      "requires": {
+        "@liff/add-to-home-screen": "2.22.2",
+        "@liff/check-availability": "2.22.2",
+        "@liff/consts": "2.22.2",
+        "@liff/get-advertising-id": "2.22.2",
+        "@liff/get-line-version": "2.22.2",
+        "@liff/get-os": "2.22.2",
+        "@liff/logger": "2.22.2",
+        "@liff/scan-code": "2.22.2",
+        "@liff/store": "2.22.2",
+        "@liff/types": "2.22.2",
+        "@liff/util": "2.22.2"
       }
     },
     "@liff/get-advertising-id": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/get-advertising-id/-/get-advertising-id-2.21.3.tgz",
-      "integrity": "sha512-wa4SFXgSF0aYIe/jhv2fDQR29b8Oy8Zxgu8r8lPk3YMXWqEZVKu9yPX7G2nQOi+vqWmTXUfGuY35eKtVoPuf4Q==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/get-advertising-id/-/get-advertising-id-2.22.2.tgz",
+      "integrity": "sha512-ZlYOXGL7GcGFbIAAnrh+cju6+BnWXPC2GCbtWAKFb+cMc8F8DswD/+f8qG5rVIB/t78j+tTjP0cDBRsSFzboOQ==",
       "dev": true,
       "requires": {
-        "@liff/check-availability": "2.21.3",
-        "@liff/consts": "2.21.3",
-        "@liff/native-bridge": "2.21.3",
-        "@liff/util": "2.21.3"
+        "@liff/types": "2.22.2"
       }
     },
     "@liff/get-friendship": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/get-friendship/-/get-friendship-2.21.3.tgz",
-      "integrity": "sha512-YCfYqeA74juAi7QGAlgksSXGsz9L7j+Lk+Z4wT01Csa1u6r1Km2NFvV+coxxwzAkcXmzX7plyWRtN611FNqXkw==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/get-friendship/-/get-friendship-2.22.2.tgz",
+      "integrity": "sha512-TqqO0M4QHGqP431mYoRRemTlW1zSz6ihjMS0cuGuPqFAvS5/gQ+8wUQOaIHR/oB0NZSOSNTZnayJ/+FFQPInVw==",
       "dev": true,
       "requires": {
-        "@liff/server-api": "2.21.3"
+        "@liff/permission": "2.22.2",
+        "@liff/server-api": "2.22.2",
+        "@liff/use": "2.22.2"
       }
     },
     "@liff/get-language": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/get-language/-/get-language-2.21.3.tgz",
-      "integrity": "sha512-/A8bfmMczEZ+JfobB3BFgH3FUAVIg2l9fkQjZvBoAvt0S/uZudhquj8Ar7oI7yBAI4usH9W5tyUqiWP0lEhlMg==",
-      "dev": true,
-      "requires": {}
-    },
-    "@liff/get-line-version": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/get-line-version/-/get-line-version-2.21.3.tgz",
-      "integrity": "sha512-uNS3cpumPRq+qstOLgzFjapBJR9OHaEQmiBtzcDksu5xzK3+46mA6FfLOUX5FT/SLzpMauUOuJyIy1vp28Amcg==",
-      "dev": true,
-      "requires": {}
-    },
-    "@liff/get-os": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/get-os/-/get-os-2.21.3.tgz",
-      "integrity": "sha512-q48QNBeUh7zYt1q7VdEkkUx9OudJrqDkG3EdhmRuxt6H4dxzXux1/oGXnl4ZWMrVLSQRCvu0Y3c4KHgh6hqmug==",
-      "dev": true,
-      "requires": {}
-    },
-    "@liff/get-profile": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/get-profile/-/get-profile-2.21.3.tgz",
-      "integrity": "sha512-jbVMFcaq8zTwJpLljD+AP71LQ6od0iNrT/JECSeGHd0ZgOsywbbNzi7jqZkh/0YJeios8xif4PKz3SHbJGpbVw==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/get-language/-/get-language-2.22.2.tgz",
+      "integrity": "sha512-+4vWYrOIFQpZMx75xLSVf1ZuNN2snh75dVHZ+TG/fl00VNgJF5sHkvglfy9dUNJkW7dMD61n3OSZUepgQUZBwA==",
       "dev": true,
       "requires": {
-        "@liff/server-api": "2.21.3"
+        "@liff/use": "2.22.2"
+      }
+    },
+    "@liff/get-line-version": {
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/get-line-version/-/get-line-version-2.22.2.tgz",
+      "integrity": "sha512-CdKB0bpvenNbtRPeUCRwMJlULf7XWY3rC3AA/6qiIYv2eLdJnwc7jQvKv0Ma9Q1w1aQkQAYi5VJqYAVfeOu31Q==",
+      "dev": true,
+      "requires": {
+        "@liff/use": "2.22.2"
+      }
+    },
+    "@liff/get-os": {
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/get-os/-/get-os-2.22.2.tgz",
+      "integrity": "sha512-N/gXG0zwR8O/ccYJhsSIxZ5UYEFvzKU+b7bbHAqDmIkq0pdBZ1YMTIL5iizbmpJQFl2+bfPWa3ultBG9X41TdA==",
+      "dev": true,
+      "requires": {
+        "@liff/use": "2.22.2"
+      }
+    },
+    "@liff/get-profile": {
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/get-profile/-/get-profile-2.22.2.tgz",
+      "integrity": "sha512-nb3ljhpgawNpFJGNKMXHbGQIf+nSNUbPION0dcrw6PplRz/Y98DxqR56onioH0e2cuRlwzp2o+Tl90JpdSrJZA==",
+      "dev": true,
+      "requires": {
+        "@liff/permission": "2.22.2",
+        "@liff/server-api": "2.22.2",
+        "@liff/use": "2.22.2"
       }
     },
     "@liff/get-version": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/get-version/-/get-version-2.21.3.tgz",
-      "integrity": "sha512-mkzEhzcWTGkHzlH1D5TS2QIgMsLKAREX+UEfhCSOxObpsfXJX1DC1gBdnMIzrFbDLjmteUVnGKXmarzcYjBJzQ==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/get-version/-/get-version-2.22.2.tgz",
+      "integrity": "sha512-KYQBgMjfZbGM8wY+6O8O4D5NwvtzASLuPi8nwqo/Kfurb/z9K8Nyi7gZ9Ca9W6UXcStx+AC05itn0L60ZCB6Ew==",
       "dev": true,
-      "requires": {}
+      "requires": {
+        "@liff/use": "2.22.2"
+      }
     },
     "@liff/hooks": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/hooks/-/hooks-2.21.3.tgz",
-      "integrity": "sha512-CEwh1DK4jwlm5wYGJv5PDvoECRh486fSsfqwW3Zokk8NYIr1jTbob04NsImmzxN+hokFESuJDPaQsf32aOWsEA==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/hooks/-/hooks-2.22.2.tgz",
+      "integrity": "sha512-P5C05CFUT6NDgi/Ur3TKHlUUtyuEQmBGM5dXezhKLtG72WY3lYTm2Y9yAcl8VU0z829+JJpM0J68gXArH03JUg==",
       "dev": true,
       "requires": {}
     },
     "@liff/i18n": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/i18n/-/i18n-2.21.3.tgz",
-      "integrity": "sha512-aEojQEl8xyOLNRgkXaeTNLEy22MUuS3rFXmrzaoIrxYnEhLvIMN89xd7VEbv+1iUYwtB3dM0xqFoXhK6mhsUEA==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/i18n/-/i18n-2.22.2.tgz",
+      "integrity": "sha512-TIaXtONhfHc0L8HPvI0S+lyTJOHelFt+TVNLJ5/9eb4uoeqM+ksdCZcJ8PcvR4RK7R7SaNZk4n4plpGMizJcHw==",
       "dev": true,
       "requires": {
-        "@liff/consts": "2.21.3",
-        "@liff/server-api": "2.21.3",
-        "@liff/use": "2.21.3",
-        "@liff/util": "2.21.3"
+        "@liff/consts": "2.22.2",
+        "@liff/server-api": "2.22.2",
+        "@liff/use": "2.22.2",
+        "@liff/util": "2.22.2"
       }
     },
     "@liff/init": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/init/-/init-2.21.3.tgz",
-      "integrity": "sha512-40AMTpO40AIxQ0+pSRIBKMCT2Y4xDmCx/qOQSqHKb3r1x8IUdz4yttqgUtAO9Pr/TQVr2F23i9DfDcsHGFtKvg==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/init/-/init-2.22.2.tgz",
+      "integrity": "sha512-wgywnI8dIhgr5bJkKqUaGrd71lgk/HGVNlWtt0y7/pV/Yp4yjKwn9Pzk9EwhjpPSUvVD+V9EaKYwkhRcHwbnkw==",
       "dev": true,
       "requires": {
-        "@liff/close-window": "2.21.3",
-        "@liff/consts": "2.21.3",
-        "@liff/extensions": "2.21.3",
-        "@liff/get-line-version": "2.21.3",
-        "@liff/get-os": "2.21.3",
-        "@liff/hooks": "2.21.3",
-        "@liff/i18n": "2.21.3",
-        "@liff/is-api-available": "2.21.3",
-        "@liff/is-in-client": "2.21.3",
-        "@liff/is-logged-in": "2.21.3",
-        "@liff/is-sub-window": "2.21.3",
-        "@liff/logger": "2.21.3",
-        "@liff/login": "2.21.3",
-        "@liff/logout": "2.21.3",
-        "@liff/message-bus": "2.21.3",
-        "@liff/native-bridge": "2.21.3",
-        "@liff/ready": "2.21.3",
-        "@liff/server-api": "2.21.3",
-        "@liff/store": "2.21.3",
-        "@liff/sub-window": "2.21.3",
-        "@liff/types": "2.21.3",
-        "@liff/use": "2.21.3",
-        "@liff/util": "2.21.3"
+        "@liff/check-availability": "2.22.2",
+        "@liff/close-window": "2.22.2",
+        "@liff/consts": "2.22.2",
+        "@liff/extensions": "2.22.2",
+        "@liff/get-line-version": "2.22.2",
+        "@liff/get-os": "2.22.2",
+        "@liff/hooks": "2.22.2",
+        "@liff/i18n": "2.22.2",
+        "@liff/is-api-available": "2.22.2",
+        "@liff/is-in-client": "2.22.2",
+        "@liff/is-logged-in": "2.22.2",
+        "@liff/is-sub-window": "2.22.2",
+        "@liff/logger": "2.22.2",
+        "@liff/login": "2.22.2",
+        "@liff/logout": "2.22.2",
+        "@liff/message-bus": "2.22.2",
+        "@liff/native-bridge": "2.22.2",
+        "@liff/ready": "2.22.2",
+        "@liff/server-api": "2.22.2",
+        "@liff/store": "2.22.2",
+        "@liff/sub-window": "2.22.2",
+        "@liff/types": "2.22.2",
+        "@liff/use": "2.22.2",
+        "@liff/util": "2.22.2"
       }
     },
     "@liff/is-api-available": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/is-api-available/-/is-api-available-2.21.3.tgz",
-      "integrity": "sha512-V6MYuSTLgkWQuVKLugW1cd8F1owgv5iklnTN8idcqrmCawTmSly/DBZFxlVcixPvaUUCk5gIIwx8czCGzfkniQ==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/is-api-available/-/is-api-available-2.22.2.tgz",
+      "integrity": "sha512-/15yBskA/uM4OnTt3Ca3lWPgHArYztEL+geMgQOLhYpFvorjyaREynllbpc4cUL5qACM+JfiN4T5frtzS/Sbsw==",
       "dev": true,
       "requires": {
-        "@liff/consts": "2.21.3",
-        "@liff/get-line-version": "2.21.3",
-        "@liff/is-in-client": "2.21.3",
-        "@liff/is-logged-in": "2.21.3",
-        "@liff/store": "2.21.3",
-        "@liff/util": "2.21.3"
+        "@liff/consts": "2.22.2",
+        "@liff/get-line-version": "2.22.2",
+        "@liff/is-in-client": "2.22.2",
+        "@liff/is-logged-in": "2.22.2",
+        "@liff/is-sub-window": "2.22.2",
+        "@liff/store": "2.22.2",
+        "@liff/use": "2.22.2",
+        "@liff/util": "2.22.2"
       }
     },
     "@liff/is-in-client": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/is-in-client/-/is-in-client-2.21.3.tgz",
-      "integrity": "sha512-X6pb9z9KmlTSL62+TzHi88Q0K7TvVW78T+/SnYi/6sRrcayokwBT/Y34kS3STXB5lHeTNodLm1aDVCFciUlTDA==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/is-in-client/-/is-in-client-2.22.2.tgz",
+      "integrity": "sha512-ovh/9VgSiTooyE9YsEokyW/4bCrULbrbjIXtFZn2NNyPQqjMMeiaZxx1nn8RDRhE82rxYO39/SC3tieSWU7fYg==",
       "dev": true,
       "requires": {
-        "@liff/consts": "2.21.3",
-        "@liff/util": "2.21.3"
+        "@liff/consts": "2.22.2",
+        "@liff/use": "2.22.2",
+        "@liff/util": "2.22.2"
       }
     },
     "@liff/is-logged-in": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/is-logged-in/-/is-logged-in-2.21.3.tgz",
-      "integrity": "sha512-s5Hg5YeW4ENv3M0Dvfw5oajcfa4BhqSKRI6JMXyoUw2j3hmIKCPCUQbOH97MiRSojiwdC4MMyReDqHFM7nskug==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/is-logged-in/-/is-logged-in-2.22.2.tgz",
+      "integrity": "sha512-nyr5Cq4PSMMjIIdcSkzcb7g2YeRnM3LO+ih1XTg1k3qkz0quXchUMpKM4CBqK6J9JKwjcXKQQlU0g5taBQtGAA==",
       "dev": true,
       "requires": {
-        "@liff/store": "2.21.3"
+        "@liff/store": "2.22.2",
+        "@liff/use": "2.22.2"
       }
     },
     "@liff/is-sub-window": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/is-sub-window/-/is-sub-window-2.21.3.tgz",
-      "integrity": "sha512-tsFML2gF23v1+it8T4XFDGl8fofniOvUjSINaEryruPmhGpUlTQ1UA51isF9cvbp4KocwpuH24S/wj9xaOic4Q==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/is-sub-window/-/is-sub-window-2.22.2.tgz",
+      "integrity": "sha512-c3BNZPexkxwndRkXx5gestpqFjnL4VbvIWWmgv3JZaeuyBjFOpoUeBWC0+W3Hah6A/KVgoW/pq2MW3XqFWQrHA==",
       "dev": true,
       "requires": {
-        "@liff/consts": "2.21.3",
-        "@liff/is-in-client": "2.21.3",
-        "@liff/store": "2.21.3",
-        "@liff/use": "2.21.3",
-        "@liff/util": "2.21.3"
+        "@liff/consts": "2.22.2",
+        "@liff/is-in-client": "2.22.2",
+        "@liff/store": "2.22.2",
+        "@liff/use": "2.22.2",
+        "@liff/util": "2.22.2"
       }
     },
     "@liff/liff-types": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/liff-types/-/liff-types-2.21.3.tgz",
-      "integrity": "sha512-WcqzMpgz/IMVmtkDuwc+L5qKW9v2iJOFBWuuWhsa5m/pSkOfnJMXxt/YHuNBWRNSQhMdRyyTspT0ByS7fWLUsg==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/liff-types/-/liff-types-2.22.2.tgz",
+      "integrity": "sha512-5vs/EvQQIw6OBjWa8RoHTcvZK46XpXtnMWndzLWH39DbqqaoMMggNNIRtJGhJJvHa1AWCXPmkJ6ykv5HRJMdHA==",
       "dev": true,
       "requires": {
-        "@liff/analytics": "2.21.3",
-        "@liff/close-window": "2.21.3",
-        "@liff/get-friendship": "2.21.3",
-        "@liff/get-language": "2.21.3",
-        "@liff/get-line-version": "2.21.3",
-        "@liff/get-os": "2.21.3",
-        "@liff/get-profile": "2.21.3",
-        "@liff/get-version": "2.21.3",
-        "@liff/i18n": "2.21.3",
-        "@liff/init": "2.21.3",
-        "@liff/is-api-available": "2.21.3",
-        "@liff/is-in-client": "2.21.3",
-        "@liff/is-logged-in": "2.21.3",
-        "@liff/is-sub-window": "2.21.3",
-        "@liff/login": "2.21.3",
-        "@liff/logout": "2.21.3",
-        "@liff/native-bridge": "2.21.3",
-        "@liff/open-window": "2.21.3",
-        "@liff/permanent-link": "2.21.3",
-        "@liff/permission": "2.21.3",
-        "@liff/ready": "2.21.3",
-        "@liff/scan-code-v2": "2.21.3",
-        "@liff/send-messages": "2.21.3",
-        "@liff/share-target-picker": "2.21.3",
-        "@liff/store": "2.21.3",
-        "@liff/sub-window": "2.21.3",
-        "@liff/use": "2.21.3"
+        "@liff/analytics": "2.22.2",
+        "@liff/close-window": "2.22.2",
+        "@liff/get-friendship": "2.22.2",
+        "@liff/get-language": "2.22.2",
+        "@liff/get-line-version": "2.22.2",
+        "@liff/get-os": "2.22.2",
+        "@liff/get-profile": "2.22.2",
+        "@liff/get-version": "2.22.2",
+        "@liff/i18n": "2.22.2",
+        "@liff/init": "2.22.2",
+        "@liff/is-api-available": "2.22.2",
+        "@liff/is-in-client": "2.22.2",
+        "@liff/is-logged-in": "2.22.2",
+        "@liff/is-sub-window": "2.22.2",
+        "@liff/login": "2.22.2",
+        "@liff/logout": "2.22.2",
+        "@liff/native-bridge": "2.22.2",
+        "@liff/open-window": "2.22.2",
+        "@liff/permanent-link": "2.22.2",
+        "@liff/permission": "2.22.2",
+        "@liff/ready": "2.22.2",
+        "@liff/scan-code-v2": "2.22.2",
+        "@liff/send-messages": "2.22.2",
+        "@liff/share-target-picker": "2.22.2",
+        "@liff/store": "2.22.2",
+        "@liff/sub-window": "2.22.2",
+        "@liff/use": "2.22.2"
       }
     },
     "@liff/logger": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/logger/-/logger-2.21.3.tgz",
-      "integrity": "sha512-Jho+01e6naJChEzsLtzNptfLOLQtvIQlHH8rO5mnG3VvtU4kgSacVVn9FhaSIVfkVYtifCLP2vHmJ55++I0KJA==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/logger/-/logger-2.22.2.tgz",
+      "integrity": "sha512-F4AGX3YUrUyKFyn0ITMa7RwUN2ccyngucCHKnLZ5rA2Ospj9WFRD9Ytb/ijXlDi+DCbaVNDsY8vatwRfDxQiXQ==",
       "dev": true,
       "requires": {}
     },
     "@liff/login": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/login/-/login-2.21.3.tgz",
-      "integrity": "sha512-5+mO3FVCGhcEq8dCwzEEvEBJuIImo3x6aIyXu9vXAkjm/Q3nqNprSBPVtPeey7z0qMmMkFxfNFf0L17sczPGTQ==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/login/-/login-2.22.2.tgz",
+      "integrity": "sha512-s7SZHKrCS9VK5GMbbpsIZKRxHQF8PKM6zNCwyHa3njJhEbRzsOkDLTfypicmulfqs/OMrXVmd1ZPya1FvV0vgw==",
       "dev": true,
       "requires": {
-        "@liff/consts": "2.21.3",
-        "@liff/get-version": "2.21.3",
-        "@liff/hooks": "2.21.3",
-        "@liff/is-in-client": "2.21.3",
-        "@liff/is-sub-window": "2.21.3",
-        "@liff/logger": "2.21.3",
-        "@liff/server-api": "2.21.3",
-        "@liff/store": "2.21.3",
-        "@liff/sub-window": "2.21.3",
-        "@liff/use": "2.21.3",
-        "@liff/util": "2.21.3",
+        "@liff/consts": "2.22.2",
+        "@liff/get-version": "2.22.2",
+        "@liff/hooks": "2.22.2",
+        "@liff/is-in-client": "2.22.2",
+        "@liff/is-sub-window": "2.22.2",
+        "@liff/logger": "2.22.2",
+        "@liff/server-api": "2.22.2",
+        "@liff/store": "2.22.2",
+        "@liff/sub-window": "2.22.2",
+        "@liff/use": "2.22.2",
+        "@liff/util": "2.22.2",
         "tiny-sha256": "^1.0.2"
       }
     },
     "@liff/logout": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/logout/-/logout-2.21.3.tgz",
-      "integrity": "sha512-OYu11KurMh7FWn9aWt8VXGaCKHaVjJdMOjp7uGZx9NSOOppSJ+QJQ/m3L091auNmNKGz2cJkO3ywzpZcGcYPTA==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/logout/-/logout-2.22.2.tgz",
+      "integrity": "sha512-fcPbPPwSqtjGKLtTx/GBPukQOYarSbDZ7XLwg+bADzwJUOPm+cCKIVLkTBWwOi/Ahpm+p6mP133uPfa3sFuj+g==",
       "dev": true,
       "requires": {
-        "@liff/store": "2.21.3"
+        "@liff/store": "2.22.2",
+        "@liff/use": "2.22.2"
       }
     },
     "@liff/message-bus": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/message-bus/-/message-bus-2.21.3.tgz",
-      "integrity": "sha512-1AtuOs/7PFE2gFb0z2XmF+nMIt3K4X9x1irSZ3yOarfuFvZgCuaEAxRnOWmWhUKgTllYNmvDGjLrd/bqOQvFWg==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/message-bus/-/message-bus-2.22.2.tgz",
+      "integrity": "sha512-IhK4MQ99atJxZWsPAo4lmgM52fhneODZRxLAwljVnU6xkVThYFeqmkMO3WLxZUulYLsvKIW/EwCh+EXZUzP7Sw==",
       "dev": true,
       "requires": {
-        "@liff/consts": "2.21.3",
-        "@liff/store": "2.21.3",
-        "@liff/util": "2.21.3"
+        "@liff/consts": "2.22.2",
+        "@liff/store": "2.22.2",
+        "@liff/util": "2.22.2"
       }
     },
     "@liff/native-bridge": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/native-bridge/-/native-bridge-2.21.3.tgz",
-      "integrity": "sha512-+knPCl0pALmhC1Ng+RB25tblLemgw+kwZQR83dAJyrU8uSjGKt8zeo9C0TTfF8nRKcKajc/6E7EwO0iLClLHQA==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/native-bridge/-/native-bridge-2.22.2.tgz",
+      "integrity": "sha512-qhY9nHdYQUKFrH7137tVYAMKbxAl68iDpdOGgY4RezGz3OcHEVtSCczw03JCNj1SoVphQVaxCcUpwvRbLWjTtg==",
       "dev": true,
       "requires": {
-        "@liff/consts": "2.21.3",
-        "@liff/logger": "2.21.3",
-        "@liff/store": "2.21.3",
-        "@liff/util": "2.21.3"
+        "@liff/consts": "2.22.2",
+        "@liff/logger": "2.22.2",
+        "@liff/store": "2.22.2",
+        "@liff/types": "2.22.2",
+        "@liff/util": "2.22.2"
       }
     },
     "@liff/open-window": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/open-window/-/open-window-2.21.3.tgz",
-      "integrity": "sha512-r0/wLewUh5uO/0lPasuQ+ZzNLVW7Z8MATEY2A/gZz6ap1R+r0HFK7grJqq+h52puYyy0Sqe2kpkMMt6CAmt2lg==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/open-window/-/open-window-2.22.2.tgz",
+      "integrity": "sha512-Rs5tzNq1o5wG19iwOW4PCYTxtq0pkuzbzXiA8iLzEzpAb+YOQFB5TrDjwVyCL5WZhvytU2wsfKsafHCk2Q4lBg==",
       "dev": true,
       "requires": {
-        "@liff/consts": "2.21.3",
-        "@liff/get-line-version": "2.21.3",
-        "@liff/get-os": "2.21.3",
-        "@liff/is-in-client": "2.21.3",
-        "@liff/native-bridge": "2.21.3",
-        "@liff/util": "2.21.3"
+        "@liff/consts": "2.22.2",
+        "@liff/get-line-version": "2.22.2",
+        "@liff/get-os": "2.22.2",
+        "@liff/is-in-client": "2.22.2",
+        "@liff/native-bridge": "2.22.2",
+        "@liff/types": "2.22.2",
+        "@liff/use": "2.22.2",
+        "@liff/util": "2.22.2"
       }
     },
     "@liff/permanent-link": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/permanent-link/-/permanent-link-2.21.3.tgz",
-      "integrity": "sha512-j+NZBWV3/v6tBmWEwpYUfKkbyc7eYR1O854w16OduFtC2d3tunLkH6p+UMg+sic1l+GrtUA6K/Xi3UG/JF+fZw==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/permanent-link/-/permanent-link-2.22.2.tgz",
+      "integrity": "sha512-K7qFlV27eF4D5cuYTyF5Edld0Djff6n3SqlJtq196QYIg5KP5cx6Ey+VnocvbFbRKzUILd9Wo4yJy7er30YrMQ==",
       "dev": true,
       "requires": {
-        "@liff/consts": "2.21.3",
-        "@liff/server-api": "2.21.3",
-        "@liff/store": "2.21.3",
-        "@liff/use": "2.21.3",
-        "@liff/util": "2.21.3"
+        "@liff/consts": "2.22.2",
+        "@liff/server-api": "2.22.2",
+        "@liff/store": "2.22.2",
+        "@liff/use": "2.22.2",
+        "@liff/util": "2.22.2"
       }
     },
     "@liff/permission": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/permission/-/permission-2.21.3.tgz",
-      "integrity": "sha512-U5Dr23pQjLIxgr+YlcdkgjOeiRoyn2rINPMplXRY4DgYaGkC0RJmm9y+V8rTIDPsrtG25SHApT5qRG6tNu9LDA==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/permission/-/permission-2.22.2.tgz",
+      "integrity": "sha512-FoT+x07juIZjv5onx/i/ADSq7Hye7i0fR9kP3fNPi7XELtWhGnveCGUGF7eA4psk5lAphsJmw5yLWT1AnnJH9A==",
       "dev": true,
       "requires": {
-        "@liff/consts": "2.21.3",
-        "@liff/is-api-available": "2.21.3",
-        "@liff/is-in-client": "2.21.3",
-        "@liff/server-api": "2.21.3",
-        "@liff/store": "2.21.3",
-        "@liff/sub-window": "2.21.3",
-        "@liff/use": "2.21.3",
-        "@liff/util": "2.21.3"
+        "@liff/consts": "2.22.2",
+        "@liff/is-api-available": "2.22.2",
+        "@liff/is-in-client": "2.22.2",
+        "@liff/server-api": "2.22.2",
+        "@liff/store": "2.22.2",
+        "@liff/sub-window": "2.22.2",
+        "@liff/use": "2.22.2",
+        "@liff/util": "2.22.2"
       }
     },
     "@liff/ready": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/ready/-/ready-2.21.3.tgz",
-      "integrity": "sha512-pkn9zD84d2h090WctchOjRiYrOoa0oWvQja0f1KXnqxyCqrowwG31fyuXsONG3dzzrzHdUAuo9VGZXgjL0RROQ==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/ready/-/ready-2.22.2.tgz",
+      "integrity": "sha512-2kdlH9KAdHkX/XU/0nsZ5kPSc2Z3aKN+rNusBsRWrGIwR9iRAnYkLP/kMr2UXIeloHTxwNNUSUCkJV58t/mTIw==",
       "dev": true,
       "requires": {}
     },
     "@liff/scan-code": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/scan-code/-/scan-code-2.21.3.tgz",
-      "integrity": "sha512-C1eF8liy/z89JfKcV91Y14AVtDEZ6l/YpdJB14k1uNIJGQeIt6dKs7rsJ7W5aulhV3E87f7j6OVrfl0liAOsUQ==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/scan-code/-/scan-code-2.22.2.tgz",
+      "integrity": "sha512-irsDX4JnIsbqIx9epbLJyX6qfXEmVqelTUmOown4XDFpasq5TMaqXWPjauNljPwWrAOHM79Vus4fRMQYnIJp0Q==",
       "dev": true,
       "requires": {
-        "@liff/check-availability": "2.21.3",
-        "@liff/consts": "2.21.3",
-        "@liff/native-bridge": "2.21.3",
-        "@liff/util": "2.21.3"
+        "@liff/types": "2.22.2"
       }
     },
     "@liff/scan-code-v2": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/scan-code-v2/-/scan-code-v2-2.21.3.tgz",
-      "integrity": "sha512-Cq3xe3ITAgR0GeJokoFX4dXuIc37eIGQt2AdAnxgk6oduqVUt0VxhG3kDaTtEC/qY6N9AFoQfFv69FJjmVAhRQ==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/scan-code-v2/-/scan-code-v2-2.22.2.tgz",
+      "integrity": "sha512-8PzRlWKhtFzHjvasv/ToZSqDIZYeOaNc6iEhrUJDIvNcyoCZkjT11lFAuEjkjxelY1z+ZBDjnQ4TVl0AJHFKjg==",
       "dev": true,
       "requires": {
-        "@liff/consts": "2.21.3",
-        "@liff/is-api-available": "2.21.3",
-        "@liff/sub-window": "2.21.3",
-        "@liff/use": "2.21.3",
-        "@liff/util": "2.21.3"
+        "@liff/consts": "2.22.2",
+        "@liff/is-api-available": "2.22.2",
+        "@liff/sub-window": "2.22.2",
+        "@liff/use": "2.22.2",
+        "@liff/util": "2.22.2"
       }
     },
     "@liff/send-messages": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/send-messages/-/send-messages-2.21.3.tgz",
-      "integrity": "sha512-URY0NCbBOXap4wTAcFadIGhYoRHR/qWGQWxBptAsDS9ZHk8wvnZzaNd0MZI3NkfkaCxRJbhpeIlBM2QQHE/48g==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/send-messages/-/send-messages-2.22.2.tgz",
+      "integrity": "sha512-qaquONL9Ag9dnrBf6KfI5KFtkkW3T7y00dNCZddgbf5WitNUJ1fEjuHr2HHEXTF6H6v3JusIXxUrIhBnwzP6yQ==",
       "dev": true,
       "requires": {
-        "@liff/consts": "2.21.3",
-        "@liff/get-line-version": "2.21.3",
-        "@liff/get-os": "2.21.3",
-        "@liff/server-api": "2.21.3",
-        "@liff/util": "2.21.3",
+        "@liff/consts": "2.22.2",
+        "@liff/get-line-version": "2.22.2",
+        "@liff/get-os": "2.22.2",
+        "@liff/permission": "2.22.2",
+        "@liff/server-api": "2.22.2",
+        "@liff/use": "2.22.2",
+        "@liff/util": "2.22.2",
         "@line/bot-sdk": "^7.0.0"
       }
     },
     "@liff/server-api": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/server-api/-/server-api-2.21.3.tgz",
-      "integrity": "sha512-svsYws90xLCqodYMhjdiWlESfN5OKDJwvKl9pnE+3HRKvXAK0ize0CZWJMCEPXkyay9eGJsWc8wTlO7rkM4brg==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/server-api/-/server-api-2.22.2.tgz",
+      "integrity": "sha512-5VWu4+mXAj+XV3WOw63z/M4krC6pOD8gt7Y/primouBZO4uFdNTSu/UP7th023EWn+FOZ4i5OhIx4hMEUDB6zw==",
       "dev": true,
       "requires": {
-        "@liff/consts": "2.21.3",
-        "@liff/store": "2.21.3",
-        "@liff/util": "2.21.3"
+        "@liff/consts": "2.22.2",
+        "@liff/store": "2.22.2",
+        "@liff/util": "2.22.2"
       }
     },
     "@liff/share-target-picker": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/share-target-picker/-/share-target-picker-2.21.3.tgz",
-      "integrity": "sha512-RbgM5jfK9wUth/GDRLRT/hsWYfOsXcKSjSZho0jsUhzGrIBWoMrEPZTOZASgN+9WtwosarCxZLiKwFoK/AWOdA==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/share-target-picker/-/share-target-picker-2.22.2.tgz",
+      "integrity": "sha512-385drTUsFCKhaow0YkYiOJHZNohtNC+SXp6JD5wzLX1w50dlGfpewuOESSGhfEvdvNk0JiM4rF3tb8tdEZUlgQ==",
       "dev": true,
       "requires": {
-        "@liff/analytics": "2.21.3",
-        "@liff/consts": "2.21.3",
-        "@liff/get-line-version": "2.21.3",
-        "@liff/get-os": "2.21.3",
-        "@liff/is-in-client": "2.21.3",
-        "@liff/is-logged-in": "2.21.3",
-        "@liff/is-sub-window": "2.21.3",
-        "@liff/logger": "2.21.3",
-        "@liff/send-messages": "2.21.3",
-        "@liff/server-api": "2.21.3",
-        "@liff/store": "2.21.3",
-        "@liff/types": "2.21.3",
-        "@liff/use": "2.21.3",
-        "@liff/util": "2.21.3",
-        "@liff/window-postmessage": "2.21.3"
+        "@liff/analytics": "2.22.2",
+        "@liff/consts": "2.22.2",
+        "@liff/get-line-version": "2.22.2",
+        "@liff/get-os": "2.22.2",
+        "@liff/is-api-available": "2.22.2",
+        "@liff/is-in-client": "2.22.2",
+        "@liff/is-logged-in": "2.22.2",
+        "@liff/is-sub-window": "2.22.2",
+        "@liff/logger": "2.22.2",
+        "@liff/send-messages": "2.22.2",
+        "@liff/server-api": "2.22.2",
+        "@liff/store": "2.22.2",
+        "@liff/types": "2.22.2",
+        "@liff/use": "2.22.2",
+        "@liff/util": "2.22.2",
+        "@liff/window-postmessage": "2.22.2"
       }
     },
     "@liff/store": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/store/-/store-2.21.3.tgz",
-      "integrity": "sha512-bMs6Ur4dkfm4JQbdMqKHzT/pz+P62vVT5+xXLbmxSvJtXxKenmizpwzuNLTRKbzugfyEX+vJZ+EsktFHBZYCuQ==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/store/-/store-2.22.2.tgz",
+      "integrity": "sha512-Zjixe2vbF5effVI+Bd/PlV8aQyHVwrSKt+86fh8SwHXvA7dwiXq3d2o8alu4anPHIGb0Z0uCsLx92wW6EyCuZw==",
       "dev": true,
       "requires": {
-        "@liff/consts": "2.21.3",
-        "@liff/is-in-client": "2.21.3",
-        "@liff/types": "2.21.3",
-        "@liff/util": "2.21.3"
+        "@liff/consts": "2.22.2",
+        "@liff/is-in-client": "2.22.2",
+        "@liff/types": "2.22.2",
+        "@liff/use": "2.22.2",
+        "@liff/util": "2.22.2"
       }
     },
     "@liff/sub-window": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/sub-window/-/sub-window-2.21.3.tgz",
-      "integrity": "sha512-WWWW6LtsYZ8/slvvUGUfSkaBk/GTgqXqEYyqk3mYSeTs/vvLJYRzi6tLJVKtBmeIWrQcxXCOBGnQaIMEWGbXew==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/sub-window/-/sub-window-2.22.2.tgz",
+      "integrity": "sha512-z44+hpgFIV9WTf5qqpcUbKet65mRjGSJw+HBRSjp1BFTSCSrO5wFrDG0VU43Qb+6UA36pbl9/iirb2J0j/itUA==",
       "dev": true,
       "requires": {
-        "@liff/close-window": "2.21.3",
-        "@liff/consts": "2.21.3",
-        "@liff/get-os": "2.21.3",
-        "@liff/is-api-available": "2.21.3",
-        "@liff/is-in-client": "2.21.3",
-        "@liff/is-sub-window": "2.21.3",
-        "@liff/logger": "2.21.3",
-        "@liff/message-bus": "2.21.3",
-        "@liff/server-api": "2.21.3",
-        "@liff/store": "2.21.3",
-        "@liff/util": "2.21.3"
+        "@liff/close-window": "2.22.2",
+        "@liff/consts": "2.22.2",
+        "@liff/get-os": "2.22.2",
+        "@liff/is-api-available": "2.22.2",
+        "@liff/is-in-client": "2.22.2",
+        "@liff/is-sub-window": "2.22.2",
+        "@liff/logger": "2.22.2",
+        "@liff/message-bus": "2.22.2",
+        "@liff/server-api": "2.22.2",
+        "@liff/store": "2.22.2",
+        "@liff/use": "2.22.2",
+        "@liff/util": "2.22.2"
       }
     },
     "@liff/types": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/types/-/types-2.21.3.tgz",
-      "integrity": "sha512-YuQXAYi7WQTtUb7MCziszJpknFq3jSHEP/Uc1CfUiFaC/fYr9p3+2WC15FJ+OYl2XrcKqAi9pDrw/P1c81ygVQ==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/types/-/types-2.22.2.tgz",
+      "integrity": "sha512-wFFy6U93U9Bc6wMTLRrkonbCsfTT5YsCeCuov4N5Wbx7cAugkp9fdDuIzIQ7oScItKxm2Qhv+LR72x/mDcgN4w==",
       "dev": true
     },
     "@liff/use": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/use/-/use-2.21.3.tgz",
-      "integrity": "sha512-XegeLHVZZfOaHxkHuRZvVDhh26COuInnpbRo1gz1PQzrBUFpZNCG4t/mLli0z2go9D66g1dHokq6PE1zuoZvpA==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/use/-/use-2.22.2.tgz",
+      "integrity": "sha512-9XluXhVXn92dCXAvI/jAmUJXelVheZMkNI0tvntvgEghQSJBvQw9T9SmjgK8nysEbC9DMM2clgdpwM2z7G/acA==",
       "dev": true,
       "requires": {
-        "@liff/hooks": "2.21.3",
-        "@liff/logger": "2.21.3"
+        "@liff/hooks": "2.22.2",
+        "@liff/logger": "2.22.2"
       }
     },
     "@liff/util": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/util/-/util-2.21.3.tgz",
-      "integrity": "sha512-45U9o2sBC4hxFFb9ghOmygOpwRw6Qxfc3/PbZmB17qqVRBzu0+0b1IkSQg0kVWcQnQF8+AtwtihjCYfbbpJgxA==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/util/-/util-2.22.2.tgz",
+      "integrity": "sha512-HTZCwr/ni+1AAZQ2eJB7wBuDD+6x9UbZy2l/AQZ9+B6m7+Q50haVUOa1ujnFduA9TA5Wy8DrrVWiCDk5XRq5KQ==",
       "dev": true,
       "requires": {
-        "@liff/consts": "2.21.3",
-        "@liff/logger": "2.21.3"
+        "@liff/consts": "2.22.2",
+        "@liff/logger": "2.22.2"
       }
     },
     "@liff/window-postmessage": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@liff/window-postmessage/-/window-postmessage-2.21.3.tgz",
-      "integrity": "sha512-NtIpc+H0Dc130bUsJ/sOcUjKsvF2J85mfjJQ57Z4bkz+VjX9AsJgzZIUAccfvKSRMdOiGM1KNIt5rUD/iIMi4w==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@liff/window-postmessage/-/window-postmessage-2.22.2.tgz",
+      "integrity": "sha512-b6woZiEIDRoonhUtP9NVpxG9hbumDQRJa0Z0crG6N/1uPrBoglFEpuaOeCcujWuyL5Eqvmh0jXB3pCp/Zvc4Mw==",
       "dev": true,
       "requires": {
-        "@liff/consts": "2.21.3",
-        "@liff/logger": "2.21.3",
-        "@liff/util": "2.21.3"
+        "@liff/consts": "2.22.2",
+        "@liff/logger": "2.22.2",
+        "@liff/util": "2.22.2"
       }
     },
     "@line/bot-sdk": {
@@ -9919,45 +10005,45 @@
       }
     },
     "@line/liff": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@line/liff/-/liff-2.21.3.tgz",
-      "integrity": "sha512-OGUPooaZlfKmResRZCJzxp5v8WLYZHnRSwwRc7NO3xm8tm0dG965L6siBUSxm2aH0FdqKw+dyWQvGoHyF4EjIQ==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@line/liff/-/liff-2.22.2.tgz",
+      "integrity": "sha512-2qWOlf3DPZJFIh6BlvbxBC8jp8U81cx36go8LLMHTzXj4PppXtlmwMJ44ZLF1kyPvJBefVMew9qVq2Cg/sSDAA==",
       "dev": true,
       "requires": {
-        "@liff/analytics": "2.21.3",
-        "@liff/close-window": "2.21.3",
-        "@liff/consts": "2.21.3",
-        "@liff/extensions": "2.21.3",
-        "@liff/get-friendship": "2.21.3",
-        "@liff/get-language": "2.21.3",
-        "@liff/get-line-version": "2.21.3",
-        "@liff/get-os": "2.21.3",
-        "@liff/get-profile": "2.21.3",
-        "@liff/get-version": "2.21.3",
-        "@liff/hooks": "2.21.3",
-        "@liff/i18n": "2.21.3",
-        "@liff/init": "2.21.3",
-        "@liff/is-api-available": "2.21.3",
-        "@liff/is-in-client": "2.21.3",
-        "@liff/is-logged-in": "2.21.3",
-        "@liff/is-sub-window": "2.21.3",
-        "@liff/liff-types": "2.21.3",
-        "@liff/login": "2.21.3",
-        "@liff/logout": "2.21.3",
-        "@liff/native-bridge": "2.21.3",
-        "@liff/open-window": "2.21.3",
-        "@liff/permanent-link": "2.21.3",
-        "@liff/permission": "2.21.3",
-        "@liff/ready": "2.21.3",
-        "@liff/scan-code-v2": "2.21.3",
-        "@liff/send-messages": "2.21.3",
-        "@liff/server-api": "2.21.3",
-        "@liff/share-target-picker": "2.21.3",
-        "@liff/store": "2.21.3",
-        "@liff/sub-window": "2.21.3",
-        "@liff/use": "2.21.3",
-        "@liff/util": "2.21.3",
-        "promise-polyfill": "^8.1.3",
+        "@liff/analytics": "2.22.2",
+        "@liff/close-window": "2.22.2",
+        "@liff/consts": "2.22.2",
+        "@liff/core": "2.22.2",
+        "@liff/extensions": "2.22.2",
+        "@liff/get-friendship": "2.22.2",
+        "@liff/get-language": "2.22.2",
+        "@liff/get-line-version": "2.22.2",
+        "@liff/get-os": "2.22.2",
+        "@liff/get-profile": "2.22.2",
+        "@liff/get-version": "2.22.2",
+        "@liff/hooks": "2.22.2",
+        "@liff/i18n": "2.22.2",
+        "@liff/init": "2.22.2",
+        "@liff/is-api-available": "2.22.2",
+        "@liff/is-in-client": "2.22.2",
+        "@liff/is-logged-in": "2.22.2",
+        "@liff/is-sub-window": "2.22.2",
+        "@liff/liff-types": "2.22.2",
+        "@liff/login": "2.22.2",
+        "@liff/logout": "2.22.2",
+        "@liff/native-bridge": "2.22.2",
+        "@liff/open-window": "2.22.2",
+        "@liff/permanent-link": "2.22.2",
+        "@liff/permission": "2.22.2",
+        "@liff/ready": "2.22.2",
+        "@liff/scan-code-v2": "2.22.2",
+        "@liff/send-messages": "2.22.2",
+        "@liff/server-api": "2.22.2",
+        "@liff/share-target-picker": "2.22.2",
+        "@liff/store": "2.22.2",
+        "@liff/sub-window": "2.22.2",
+        "@liff/use": "2.22.2",
+        "@liff/util": "2.22.2",
         "tslib": "^2.3.0",
         "whatwg-fetch": "^3.0.0"
       }
@@ -10885,13 +10971,13 @@
       "dev": true
     },
     "body-parser": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
-      "integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
+      "version": "1.20.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
+      "integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
       "dev": true,
       "requires": {
         "bytes": "3.1.2",
-        "content-type": "~1.0.4",
+        "content-type": "~1.0.5",
         "debug": "2.6.9",
         "depd": "2.0.0",
         "destroy": "1.2.0",
@@ -10899,7 +10985,7 @@
         "iconv-lite": "0.4.24",
         "on-finished": "2.4.1",
         "qs": "6.11.0",
-        "raw-body": "2.5.1",
+        "raw-body": "2.5.2",
         "type-is": "~1.6.18",
         "unpipe": "1.0.0"
       },
@@ -11237,9 +11323,9 @@
       }
     },
     "content-type": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
       "dev": true
     },
     "convert-source-map": {
@@ -12191,13 +12277,14 @@
       "dev": true
     },
     "get-intrinsic": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
-      "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
+      "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
       "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
+        "has-proto": "^1.0.1",
         "has-symbols": "^1.0.3"
       }
     },
@@ -12290,6 +12377,12 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true
+    },
+    "has-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
+      "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
       "dev": true
     },
     "has-symbols": {
@@ -13543,9 +13636,9 @@
       "dev": true
     },
     "object-inspect": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
-      "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
+      "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
       "dev": true
     },
     "obuf": {
@@ -13807,12 +13900,6 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
     },
-    "promise-polyfill": {
-      "version": "8.2.3",
-      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.2.3.tgz",
-      "integrity": "sha512-Og0+jCRQetV84U8wVjMNccfGCnMQ9mGs9Hv78QFe+pSDD3gWTpz0y+1QCuxy5d/vBFuZ3iwP2eycAkvqIMPmWg==",
-      "dev": true
-    },
     "prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -13884,9 +13971,9 @@
       "dev": true
     },
     "raw-body": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
-      "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
       "dev": true,
       "requires": {
         "bytes": "3.1.2",
@@ -14682,9 +14769,9 @@
       }
     },
     "tslib": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+      "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
       "dev": true
     },
     "tsutils": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   ],
   "license": "Apache-2.0",
   "devDependencies": {
-    "@line/liff": "2.21.3",
+    "@line/liff": "2.22.2",
     "@types/jest": "27.4.1",
     "@typescript-eslint/eslint-plugin": "5.19.0",
     "@typescript-eslint/parser": "5.19.0",

--- a/src/api/init.ts
+++ b/src/api/init.ts
@@ -39,7 +39,7 @@ import { _removeListener } from './_removeListener';
 
 export const createMockedInit = (
   injectLiffMock: (
-    liff: Omit<ActualLiff, 'init' | 'use' | 'ready' | 'id'>
+    liff: Omit<ActualLiff, 'init' | 'use' | 'ready' | 'id' | '$mock'>
   ) => void,
   isCalledInLiffBrowser: boolean
 ): ActualLiff['init'] => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,21 @@
+import { LiffMockApi, ExtendedInit } from './type';
 export { LiffMockConfig, LiffMockApi, ExtendedInit } from './type';
 import { LiffMockPlugin } from './plugin';
 export { LiffMockPlugin } from './plugin';
 export default LiffMockPlugin;
+
+// For @line/liff v2.21.4 or earlier
+declare module '@line/liff' {
+  interface Liff {
+    init: ExtendedInit;
+    $mock: LiffMockApi;
+  }
+}
+
+// For @line/liff v2.22.0 or later
+declare module '@line/liff/exports' {
+  interface Liff {
+    init: ExtendedInit;
+    $mock: LiffMockApi;
+  }
+}


### PR DESCRIPTION
Fix https://github.com/line/liff-mock/issues/17

This PR fixes the type incompatibility issue reported in #17 to declare the extended type definitions for `@line/liff` module in the entry file of LIFF Mock. I've confirmed this declaration works fine with LIFF SDK for each version.

| with v2.19.0 | with v2.22.0 |
| -- | -- |
| <img width="449" alt="image" src="https://github.com/line/liff-mock/assets/22386678/2a84ee12-31be-4785-9ceb-f5e374421073"> | <img width="425" alt="image" src="https://github.com/line/liff-mock/assets/22386678/198a125f-aada-442f-abf7-82d6da72606f"> |

