### PR TITLE
Pin version of GitHub Actions using SHA

### DIFF
--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -11,9 +11,9 @@ jobs:
         node-version: [16.x]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 # v3.8.2
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install dependencies


### PR DESCRIPTION
## Description
To mitigate supply chain attacks in GitHub Actions, I pinned the version of GitHub Actions using SHA.
https://semgrep.dev/blog/2025/popular-github-action-tj-actionschanged-files-is-compromised/